### PR TITLE
Removing liveness probe for broker as deemed not useful

### DIFF
--- a/base/brokers.yaml
+++ b/base/brokers.yaml
@@ -121,17 +121,6 @@ spec:
                 - sh
                 - -c
                 - "unset JMX_PORT && /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server=localhost:9092"
-          livenessProbe:
-            failureThreshold: 10
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 15
-            exec:
-              command:
-                - sh
-                - -c
-                - "unset JMX_PORT && /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server=localhost:9092"
           ports:
             - containerPort: 9092
               protocol: TCP


### PR DESCRIPTION
- Following discussion with staff engineers and infra it's been decided that a liveness probe on a Kafka broker is not useful. https://utilitywarehouse.slack.com/archives/C37EHB3R6/p1657008524027729?thread_ts=1656922296.436089&cid=C37EHB3R6