### PR TITLE
Remove podAfinity and nodeAfinity from Statefulset 

### DIFF
--- a/bitnami/shared/upstream/kustomization.yaml
+++ b/bitnami/shared/upstream/kustomization.yaml
@@ -38,3 +38,12 @@ patches:
     target:
       group: apps
       version: v1 # Deployment | StatefulSet
+  - patch: |-
+      - op: remove
+        path: /spec/template/spec/affinity/podAffinity
+      - op: remove
+        path: /spec/template/spec/affinity/nodeAffinity
+    target:
+      group: apps
+      version: v1 # Deployment | StatefulSet
+      kind: StatefulSet

--- a/bitnami/shared/upstream/kustomization.yaml
+++ b/bitnami/shared/upstream/kustomization.yaml
@@ -38,6 +38,8 @@ patches:
     target:
       group: apps
       version: v1 # Deployment | StatefulSet
+  # remove these empty affinity nodes, as in Kustomize 5.0.x kustomize generates them as strings with value "null" instead of just null, and they can not be applied.
+  # should recheck these on future kustomize versions.
   - patch: |-
       - op: remove
         path: /spec/template/spec/affinity/podAffinity


### PR DESCRIPTION
as Kustomize 5.0.x generates them as "null" strings