### PR TITLE
fix: DENA-380: bitnami kafka enable startup probe

### DIFF
--- a/bitnami/config/values-non-tls.yaml
+++ b/bitnami/config/values-non-tls.yaml
@@ -3,6 +3,8 @@ kraft:
   enabled: true
   processRoles: broker,controller
   controllerListenerNames: CONTROLLER
+startupProbe:
+  enabled: true
 deleteTopicEnable: true
 autoCreateTopicsEnable: false
 defaultReplicationFactor: 3

--- a/bitnami/config/values-non-tls.yaml
+++ b/bitnami/config/values-non-tls.yaml
@@ -5,6 +5,7 @@ kraft:
   controllerListenerNames: CONTROLLER
 startupProbe:
   enabled: true
+  initialDelaySeconds: 10
 deleteTopicEnable: true
 autoCreateTopicsEnable: false
 defaultReplicationFactor: 3

--- a/bitnami/config/values-tls.yaml
+++ b/bitnami/config/values-tls.yaml
@@ -3,6 +3,8 @@ kraft:
   enabled: true
   processRoles: broker,controller
   controllerListenerNames: CONTROLLER
+startupProbe:
+  enabled: true
 deleteTopicEnable: true
 autoCreateTopicsEnable: false
 defaultReplicationFactor: 3

--- a/bitnami/config/values-tls.yaml
+++ b/bitnami/config/values-tls.yaml
@@ -5,6 +5,7 @@ kraft:
   controllerListenerNames: CONTROLLER
 startupProbe:
   enabled: true
+  initialDelaySeconds: 10
 deleteTopicEnable: true
 autoCreateTopicsEnable: false
 defaultReplicationFactor: 3

--- a/bitnami/energy-platform/kafka-bitnami/upstream/kafka.yaml
+++ b/bitnami/energy-platform/kafka-bitnami/upstream/kafka.yaml
@@ -525,6 +525,14 @@ spec:
             timeoutSeconds: 5
             tcpSocket:
               port: kafka-client
+          startupProbe:
+            failureThreshold: 15
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            tcpSocket:
+              port: kafka-client
           resources:
             limits: {}
             requests: {}

--- a/bitnami/energy-platform/kafka-bitnami/upstream/kafka.yaml
+++ b/bitnami/energy-platform/kafka-bitnami/upstream/kafka.yaml
@@ -527,7 +527,7 @@ spec:
               port: kafka-client
           startupProbe:
             failureThreshold: 15
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/bitnami/energy/kafka-bitnami/upstream/kafka.yaml
+++ b/bitnami/energy/kafka-bitnami/upstream/kafka.yaml
@@ -525,6 +525,14 @@ spec:
             timeoutSeconds: 5
             tcpSocket:
               port: kafka-client
+          startupProbe:
+            failureThreshold: 15
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            tcpSocket:
+              port: kafka-client
           resources:
             limits: {}
             requests: {}

--- a/bitnami/energy/kafka-bitnami/upstream/kafka.yaml
+++ b/bitnami/energy/kafka-bitnami/upstream/kafka.yaml
@@ -527,7 +527,7 @@ spec:
               port: kafka-client
           startupProbe:
             failureThreshold: 15
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/bitnami/finance/kafka-bitnami/upstream/kafka.yaml
+++ b/bitnami/finance/kafka-bitnami/upstream/kafka.yaml
@@ -525,6 +525,14 @@ spec:
             timeoutSeconds: 5
             tcpSocket:
               port: kafka-client
+          startupProbe:
+            failureThreshold: 15
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            tcpSocket:
+              port: kafka-client
           resources:
             limits: {}
             requests: {}

--- a/bitnami/finance/kafka-bitnami/upstream/kafka.yaml
+++ b/bitnami/finance/kafka-bitnami/upstream/kafka.yaml
@@ -527,7 +527,7 @@ spec:
               port: kafka-client
           startupProbe:
             failureThreshold: 15
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/bitnami/pubsub/kafka-non-tls/upstream/kafka.yaml
+++ b/bitnami/pubsub/kafka-non-tls/upstream/kafka.yaml
@@ -525,6 +525,14 @@ spec:
             timeoutSeconds: 5
             tcpSocket:
               port: kafka-client
+          startupProbe:
+            failureThreshold: 15
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            tcpSocket:
+              port: kafka-client
           resources:
             limits: {}
             requests: {}

--- a/bitnami/pubsub/kafka-non-tls/upstream/kafka.yaml
+++ b/bitnami/pubsub/kafka-non-tls/upstream/kafka.yaml
@@ -527,7 +527,7 @@ spec:
               port: kafka-client
           startupProbe:
             failureThreshold: 15
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/bitnami/pubsub/kafka-shared/upstream/kafka.yaml
+++ b/bitnami/pubsub/kafka-shared/upstream/kafka.yaml
@@ -569,7 +569,7 @@ spec:
               port: kafka-client
           startupProbe:
             failureThreshold: 15
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/bitnami/pubsub/kafka-shared/upstream/kafka.yaml
+++ b/bitnami/pubsub/kafka-shared/upstream/kafka.yaml
@@ -567,6 +567,14 @@ spec:
             timeoutSeconds: 5
             tcpSocket:
               port: kafka-client
+          startupProbe:
+            failureThreshold: 15
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            tcpSocket:
+              port: kafka-client
           resources:
             limits: {}
             requests: {}


### PR DESCRIPTION
For context see the ticket: https://linear.app/utilitywarehouse/issue/DENA-380/ops-enable-startup-probe-for-the-shared-kafka

- Added startup probe for Kafka to avoid liveness probe kill loop
- Keep initial delay to 10s like the current liveness probe
