### PR TITLE
fix: PLA2-53: tune mirror-maker bases for high volumes kafkas

### DIFF
--- a/mirror-maker-2/README.md
+++ b/mirror-maker-2/README.md
@@ -6,11 +6,11 @@ Mirror Maker is the default tool to keep kafka clusters synchronized -> it can s
 This is why it is also useful when migrating between clusters and even upgrading kafka to newer versions.
 
 ## Kustomization bases in this repo
- - [flexible](flexible): this is a minimal base which is fully customizable through a properties file loaded from a ConfigMap. A [sample](flexible/config/connect-mirror-maker-sample.properties) showing the supported properties is included.
- - [active-passive with SSL support](active-passive-ssl): this base uses a mirror-maker 2 [predefined configuration template](active-passive-ssl/config/connect-mirror-maker-template.properties) that is customised through environment variables. This is done in an init container. 
-   The template is configured for an active-passive replication, and supports SSL enabled Kafka clusters. 
+ - [recommended: active-passive with SSL support](active-passive-ssl): this base uses a mirror-maker 2 [predefined configuration template](active-passive-ssl/config/connect-mirror-maker-template.properties) that is customised through environment variables. This is done in an init container. 
+   The template is configured for an active-passive replication, and supports both SSL and non SSL enabled Kafka clusters. 
    mirror-maker 2 connects to SSL enabled Kafla clusters by using password encrypted JKS truststore and keystore. 
    With this base you can pass these passwords directly from Kubernetes secrets through environment variables.
+- [flexible](flexible): this is a minimal base which is fully customizable through a properties file loaded from a ConfigMap. A [sample](flexible/config/connect-mirror-maker-sample.properties) showing the supported properties is included.
 
 ## References
 - https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27846330

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -62,11 +62,12 @@ rules:
   #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-bytes)
+  #kafka.consumer:type=producer-metrics,client-id="{clientid}"
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-record-.+|.+-error-.+|.+-outgoing-.+|.+-incoming-.+)
     name: kafka_$2_$4
     labels:
       clientId: "$3"
-    help: "Kafka $1 JMX metric type $2"
+    help: "Kafka $1 JMX metric type $2 by client-id"
     cache: true
     type: GAUGE
 

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -63,7 +63,7 @@ rules:
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
   #kafka.consumer:type=producer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.*record-.+|.*error.+|.*outgoing-.+|.*incoming-.+|.*buffer-.+)
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.*record-[^:]*|.*error[^:]*|.*outgoing-[^:]*|.*incoming-[^:]*|.*buffer-[^:]*)
     name: kafka_$2_$4
     labels:
       clientId: "$3"

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -48,16 +48,6 @@ rules:
     cache: true
     type: GAUGE
 
-#  #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
-#  #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
-#  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
-#    name: kafka_$2_$5
-#    labels:
-#      clientId: "$3"
-#      nodeId: "$4"
-#    help: "Kafka $1 JMX metric type $2"
-#    type: UNTYPED
-
   #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
   #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
@@ -80,13 +70,14 @@ rules:
       task: "$2"
       status: "$3"
     help: "Kafka Connect JMX Connector status"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
     name: kafka_connect_$1_$4
     labels:
       connector: "$2"
@@ -102,18 +93,21 @@ rules:
     labels:
       connector: "$1"
     help: "Kafka Connect JMX metric $1"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=connect-worker-metrics
   - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
     name: kafka_connect_worker_$1
     help: "Kafka Connect JMX metric worker"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=connect-worker-rebalance-metrics
   - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
     name: kafka_connect_worker_rebalance_$1
     help: "Kafka Connect JMX metric rebalance information"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=MirrorSourceConnector
@@ -124,6 +118,7 @@ rules:
       topic: "$2"
       partition: "$3"
     help: "Kafka Mirror Maker 2 Source Connector metrics"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=MirrorCheckpointConnector
@@ -136,4 +131,5 @@ rules:
       topic: "$4"
       partition: "$5"
     help: "Kafka Mirror Maker 2 Checkpoint Connector metrics"
+    cache: true
     type: GAUGE

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -14,6 +14,7 @@ rules:
     help: "Kafka $1 JMX metric start time seconds"
     type: GAUGE
     valueFactor: 0.001
+    cache: true
   - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)'
     name: kafka_$1_$3_info
     value: 1
@@ -21,48 +22,52 @@ rules:
       clientId: "$2"
       $3: "$4"
     help: "Kafka $1 JMX metric info version and commit-id"
+    cache: true
     type: GAUGE
 
   #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
   #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|.+-lag)
     name: kafka_$2_$6
     labels:
       clientId: "$3"
       topic: "$4"
       partition: "$5"
     help: "Kafka $1 JMX metric type $2"
+    cache: true
     type: GAUGE
 
   #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
-  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total|compression-rate|.+-avg)
+  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total)
     name: kafka_$2_$5
     labels:
       clientId: "$3"
       topic: "$4"
     help: "Kafka $1 JMX metric type $2"
+    cache: true
     type: GAUGE
 
-  #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
-  #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
-    name: kafka_$2_$5
-    labels:
-      clientId: "$3"
-      nodeId: "$4"
-    help: "Kafka $1 JMX metric type $2"
-    type: UNTYPED
+#  #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
+#  #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
+#  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
+#    name: kafka_$2_$5
+#    labels:
+#      clientId: "$3"
+#      nodeId: "$4"
+#    help: "Kafka $1 JMX metric type $2"
+#    type: UNTYPED
 
   #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
   #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-avg|.+-bytes|.+-count|.+-ratio|.+-age|.+-flight|.+-threads|.+-connectors|.+-tasks|.+-ago)
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-bytes)
     name: kafka_$2_$4
     labels:
       clientId: "$3"
     help: "Kafka $1 JMX metric type $2"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
@@ -86,6 +91,7 @@ rules:
       connector: "$2"
       task: "$3"
     help: "Kafka Connect JMX metric type $1"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=connector-metrics,connector="{connector}"

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -63,7 +63,7 @@ rules:
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
   #kafka.consumer:type=producer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-record-.+|.+-error-.+|.+-outgoing-.+|.+-incoming-.+)
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.*record-.+|.*error.+|.*outgoing-.+|.*incoming-.+|.*buffer-.+)
     name: kafka_$2_$4
     labels:
       clientId: "$3"

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -109,6 +109,18 @@ spec:
           args: ["5556", "/jmx-exporter-config/config.yaml"]
           ports:
             - containerPort: 5556
+          livenessProbe:
+            tcpSocket:
+              port: 5556
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5556
+            initialDelaySeconds: 30
+            # it has been reported that in cases with many topics to synchronize, it takes a long time for the first request.
+            timeoutSeconds: 300
           resources:
             requests:
               cpu: 100m

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -105,7 +105,7 @@ spec:
             - name: log4j-config
               mountPath: /log4j-config
         - name: jmx-exporter
-          image: bitnami/jmx-exporter:0.19.0
+          image: bitnami/jmx-exporter:0.20.0
           args: ["5556", "/jmx-exporter-config/config.yaml"]
           ports:
             - containerPort: 5556

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -97,7 +97,7 @@ spec:
               cpu: 400m
               memory: 1Gi
             limits:
-              cpu: "2"
+              cpu: "6"
               memory: 5Gi
           volumeMounts:
             - name: mm2-config
@@ -113,7 +113,8 @@ spec:
             tcpSocket:
               port: 5556
             initialDelaySeconds: 15
-            timeoutSeconds: 10
+            timeoutSeconds: 100
+            periodSeconds: 300
           readinessProbe:
             httpGet:
               path: /
@@ -121,6 +122,7 @@ spec:
             initialDelaySeconds: 30
             # it has been reported that in cases with many topics to synchronize, it takes a long time for the first request.
             timeoutSeconds: 300
+            periodSeconds: 300
           resources:
             requests:
               cpu: 100m

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -126,7 +126,7 @@ spec:
               cpu: 100m
               memory: 100Mi
             limits:
-              cpu: 2
+              cpu: 3
               memory: 1Gi
           volumeMounts:
             - mountPath: /jmx-exporter-config

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -106,6 +106,7 @@ spec:
               mountPath: /log4j-config
         - name: jmx-exporter
           image: bitnami/jmx-exporter:0.20.0
+          command: ["java", "-Xms256m", "-Xmx1024m", "-jar", "jmx_prometheus_httpserver.jar"]
           args: ["5556", "/jmx-exporter-config/config.yaml"]
           ports:
             - containerPort: 5556
@@ -128,8 +129,8 @@ spec:
               cpu: 100m
               memory: 100Mi
             limits:
-              cpu: 3
-              memory: 1Gi
+              cpu: 2
+              memory: 1.5Gi
           volumeMounts:
             - mountPath: /jmx-exporter-config
               name: jmx-exporter-config

--- a/mirror-maker-2/flexible/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/flexible/config/jmx-exporter-config.yaml
@@ -14,6 +14,7 @@ rules:
     help: "Kafka $1 JMX metric start time seconds"
     type: GAUGE
     valueFactor: 0.001
+    cache: true
   - pattern: 'kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)'
     name: kafka_$1_$3_info
     value: 1
@@ -21,48 +22,43 @@ rules:
       clientId: "$2"
       $3: "$4"
     help: "Kafka $1 JMX metric info version and commit-id"
+    cache: true
     type: GAUGE
 
   #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
   #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|compression-rate|.+-avg|.+-replica|.+-lag|.+-lead)
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|.+-lag)
     name: kafka_$2_$6
     labels:
       clientId: "$3"
       topic: "$4"
       partition: "$5"
     help: "Kafka $1 JMX metric type $2"
+    cache: true
     type: GAUGE
 
   #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
-  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total|compression-rate|.+-avg)
+  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total)
     name: kafka_$2_$5
     labels:
       clientId: "$3"
       topic: "$4"
     help: "Kafka $1 JMX metric type $2"
+    cache: true
     type: GAUGE
-
-  #kafka.connect:type=connect-node-metrics,client-id="{clientid}",node-id="{nodeid}"
-  #kafka.consumer:type=consumer-node-metrics,client-id=consumer-1,node-id="{nodeid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), node-id=(.+)><>(.+-total|.+-avg)
-    name: kafka_$2_$5
-    labels:
-      clientId: "$3"
-      nodeId: "$4"
-    help: "Kafka $1 JMX metric type $2"
-    type: UNTYPED
 
   #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
   #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.+-total|.+-avg|.+-bytes|.+-count|.+-ratio|.+-age|.+-flight|.+-threads|.+-connectors|.+-tasks|.+-ago)
+  #kafka.consumer:type=producer-metrics,client-id="{clientid}"
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.*record-[^:]*|.*error[^:]*|.*outgoing-[^:]*|.*incoming-[^:]*|.*buffer-[^:]*)
     name: kafka_$2_$4
     labels:
       clientId: "$3"
-    help: "Kafka $1 JMX metric type $2"
+    help: "Kafka $1 JMX metric type $2 by client-id"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
@@ -74,18 +70,20 @@ rules:
       task: "$2"
       status: "$3"
     help: "Kafka Connect JMX Connector status"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
     name: kafka_connect_$1_$4
     labels:
       connector: "$2"
       task: "$3"
     help: "Kafka Connect JMX metric type $1"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=connector-metrics,connector="{connector}"
@@ -95,18 +93,21 @@ rules:
     labels:
       connector: "$1"
     help: "Kafka Connect JMX metric $1"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=connect-worker-metrics
   - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
     name: kafka_connect_worker_$1
     help: "Kafka Connect JMX metric worker"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=connect-worker-rebalance-metrics
   - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
     name: kafka_connect_worker_rebalance_$1
     help: "Kafka Connect JMX metric rebalance information"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=MirrorSourceConnector
@@ -117,6 +118,7 @@ rules:
       topic: "$2"
       partition: "$3"
     help: "Kafka Mirror Maker 2 Source Connector metrics"
+    cache: true
     type: GAUGE
 
   #kafka.connect:type=MirrorCheckpointConnector
@@ -129,4 +131,5 @@ rules:
       topic: "$4"
       partition: "$5"
     help: "Kafka Mirror Maker 2 Checkpoint Connector metrics"
+    cache: true
     type: GAUGE

--- a/mirror-maker-2/flexible/deployment.yaml
+++ b/mirror-maker-2/flexible/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           image: bitnami/kafka:3.4
           env:
             - name: KAFKA_HEAP_OPTS
-              value: -Xmx4G -Xms500M
+              value: -Xmx4G -Xms1G
             - name: KAFKA_LOG4J_OPTS
               value: -Dlog4j.configuration=file:/log4j-config/connect-log4j.properties
             - name: JMX_PORT
@@ -39,7 +39,7 @@ spec:
               cpu: 400m
               memory: 1Gi
             limits:
-              cpu: "2"
+              cpu: "6"
               memory: 5Gi
           volumeMounts:
             - name: mm2-config
@@ -47,17 +47,32 @@ spec:
             - name: log4j-config
               mountPath: /log4j-config
         - name: jmx-exporter
-          image: bitnami/jmx-exporter:0.19.0
+          image: bitnami/jmx-exporter:0.20.0
+          command: ["java", "-Xms256m", "-Xmx1024m", "-jar", "jmx_prometheus_httpserver.jar"]
           args: ["5556", "/jmx-exporter-config/config.yaml"]
           ports:
             - containerPort: 5556
+          livenessProbe:
+            tcpSocket:
+              port: 5556
+            initialDelaySeconds: 15
+            timeoutSeconds: 100
+            periodSeconds: 300
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5556
+            initialDelaySeconds: 30
+            # it has been reported that in cases with many topics to synchronize, it takes a long time for the first request.
+            timeoutSeconds: 300
+            periodSeconds: 300
           resources:
             requests:
               cpu: 100m
               memory: 100Mi
             limits:
               cpu: 2
-              memory: 1Gi
+              memory: 1.5Gi
           volumeMounts:
             - mountPath: /jmx-exporter-config
               name: jmx-exporter-config


### PR DESCRIPTION
- trim down the metrics exposed by jmx-exporter
- added readiness & liveness probe for the jmx container
- use latest jmx-exporter image
- increase the limits for the mirror-maker 2 container, as it was severely throttled, delaying serving the metrics 
- tuned the jmx exporter memory settings

With these settings the metrics are served in under 30s (18-23s).
Tested on replicating fully the energy platform kafka:
- [mm2 replication sample](https://grafana.dev.merit.uw.systems/d/spCQwc0mz/kafka-mirror-maker-2?orgId=1&from=1701186876139&to=1701189552032&var-datasource=default&var-namespace=pubsub&var-app=mm2&var-app_kubernetes_io_name=&var-source=source)
- [container performance at this time](https://grafana.dev.merit.uw.systems/d/faeKgjeMkv2/kubernetes-pod-usage-vs-resource-app-v2?orgId=1&var-namespace=pubsub&var-app=All&var-pod=mm2-6bb85cb8b5-5dfxz&var-app_kubernetes_io_name=All&var-container=All&from=1701186870364&to=1701189687101)
