### PR TITLE
PLA2-53: start jmx exporter as java agent

### DIFF
--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -97,21 +97,14 @@ rules:
     type: GAUGE
 
   #kafka.connect:type=connect-worker-metrics
-  - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
+  - pattern: kafka.connect<type=connect-worker-metrics><>(.+-count|.+-total|.+-ms)
     name: kafka_connect_worker_$1
     help: "Kafka Connect JMX metric worker"
     cache: true
     type: GAUGE
 
-  #kafka.connect:type=connect-worker-rebalance-metrics
-  - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
-    name: kafka_connect_worker_rebalance_$1
-    help: "Kafka Connect JMX metric rebalance information"
-    cache: true
-    type: GAUGE
-
   #kafka.connect:type=MirrorSourceConnector
-  - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>([a-z-_]+)
+  - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms)
     name: kafka_connect_mirror_mirrorsourceconnector_$4
     labels:
       target: "$1"
@@ -122,7 +115,7 @@ rules:
     type: GAUGE
 
   #kafka.connect:type=MirrorCheckpointConnector
-  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+), partition=(.+)><>([a-z-_]+)
+  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms)
     name: kafka_connect_mirror_mirrorcheckpointconnector_$6
     labels:
       source: "$1"

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -115,13 +115,14 @@ rules:
     type: GAUGE
 
   #kafka.connect:type=MirrorCheckpointConnector
-  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+)><>(.+-count|.+-total|.+-ms)
+  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms)
     name: kafka_connect_mirror_mirrorcheckpointconnector_$6
     labels:
       source: "$1"
       target: "$2"
       group: "$3"
       topic: "$4"
+      partition: "$5"
     help: "Kafka Mirror Maker 2 Checkpoint Connector metrics"
     cache: true
     type: GAUGE

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -77,7 +77,7 @@ rules:
   #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped|.+-avg-time-ms)
     name: kafka_connect_$1_$4
     labels:
       connector: "$2"

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -115,14 +115,13 @@ rules:
     type: GAUGE
 
   #kafka.connect:type=MirrorCheckpointConnector
-  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms)
+  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+)><>(.+-count|.+-total|.+-ms)
     name: kafka_connect_mirror_mirrorcheckpointconnector_$6
     labels:
       source: "$1"
       target: "$2"
       group: "$3"
       topic: "$4"
-      partition: "$5"
     help: "Kafka Mirror Maker 2 Checkpoint Connector metrics"
     cache: true
     type: GAUGE

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -104,7 +104,7 @@ rules:
     type: GAUGE
 
   #kafka.connect:type=MirrorSourceConnector
-  - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms)
+  - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms|.+-rate)
     name: kafka_connect_mirror_mirrorsourceconnector_$4
     labels:
       target: "$1"

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -53,7 +53,7 @@ rules:
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
   #kafka.consumer:type=producer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.*record-send-total|.*error-total|outgoing-.+-total|incoming-.*-total|.*buffer-.*-total|.*buffer-.*-bytes)
+  - pattern: kafka.(.+)<type=(consumer-fetch-manager|consumer-coordinator|consumer|producer)-metrics, client-id=(.*)><>(.*record-send-total|.*error-total|outgoing-.+-total|incoming-.*-total|.*buffer-.*-total|.*buffer-.*-bytes)
     name: kafka_$2_$4
     labels:
       clientId: "$3"

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -1,5 +1,5 @@
 # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
-jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi
+#jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi
 
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -1,5 +1,4 @@
 # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
-#jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi
 
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -53,7 +53,7 @@ rules:
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
   #kafka.consumer:type=producer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.*record-[^:]*|.*error[^:]*|.*outgoing-[^:]*|.*incoming-[^:]*|.*buffer-[^:]*)
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.*record-send-total|.*error-total|outgoing-.+-total|incoming-.*-total|.*buffer-.*-total|.*buffer-.*-bytes)
     name: kafka_$2_$4
     labels:
       clientId: "$3"

--- a/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/active-passive-ssl/config/jmx-exporter-config.yaml
@@ -53,7 +53,7 @@ rules:
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
   #kafka.consumer:type=producer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(consumer-fetch-manager|consumer-coordinator|consumer|producer)-metrics, client-id=(.*)><>(.*record-send-total|.*error-total|outgoing-.+-total|incoming-.*-total|.*buffer-.*-total|.*buffer-.*-bytes)
+  - pattern: kafka.(.+)<type=(consumer-fetch-manager|consumer-coordinator|consumer|producer|producer-topic)-metrics, client-id=(.*)><>(.*record-send-total|.*error-total|outgoing-.+-total|incoming-.*-total|.*buffer-.*-total|.*buffer-.*-bytes)
     name: kafka_$2_$4
     labels:
       clientId: "$3"

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -137,36 +137,6 @@ spec:
             - mountPath: /jmx-exporter-config
               name: jmx-exporter-config
 
-#        - name: jmx-exporter
-#          image: bitnami/jmx-exporter:0.20.0
-#          command: ["java", "-Xms256m", "-Xmx1024m", "-jar", "jmx_prometheus_httpserver.jar"]
-#          args: ["5556", "/jmx-exporter-config/config.yaml"]
-#          ports:
-#            - containerPort: 5556
-#          livenessProbe:
-#            tcpSocket:
-#              port: 5556
-#            initialDelaySeconds: 15
-#            timeoutSeconds: 100
-#            periodSeconds: 300
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: 5556
-#            initialDelaySeconds: 30
-#            # it has been reported that in cases with many topics to synchronize, it takes a long time for the first request.
-#            timeoutSeconds: 300
-#            periodSeconds: 300
-#          resources:
-#            requests:
-#              cpu: 100m
-#              memory: 100Mi
-#            limits:
-#              cpu: 2
-#              memory: 1.5Gi
-#          volumeMounts:
-#            - mountPath: /jmx-exporter-config
-#              name: jmx-exporter-config
       volumes:
         - name: mm2-config-template
           configMap:

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -77,6 +77,16 @@ spec:
               mountPath: /config
             - name: mm2-config-template
               mountPath: /config-template
+        - name: copy-jmx-exporter-jar
+          image: bitnami/jmx-exporter:0.20.0
+          command:
+            - cp
+            - /opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar
+            - /jmx-exporter-jar/jmx_prometheus_javaagent.jar
+
+          volumeMounts:
+            - name: jmx-exporter-jar
+              mountPath: /jmx-exporter-jar
       containers:
         - name: *app
           imagePullPolicy: IfNotPresent
@@ -88,10 +98,14 @@ spec:
               value: -Dlog4j.configuration=file:/log4j-config/connect-log4j.properties
             - name: JMX_PORT
               value: "5555"
+            - name: KAFKA_OPTS
+              value: "-javaagent:/jmx-exporter-jar/jmx_prometheus_javaagent.jar=5556:/jmx-exporter-config/config.yaml"
           command:
             #  the config is mounted from file generated from a template in the init container
             - /opt/bitnami/kafka/bin/connect-mirror-maker.sh
             - /config/connect-mirror-maker.properties
+          ports:
+            - containerPort: 5556
           resources:
             requests:
               cpu: 400m
@@ -99,17 +113,6 @@ spec:
             limits:
               cpu: "6"
               memory: 5Gi
-          volumeMounts:
-            - name: mm2-config
-              mountPath: /config
-            - name: log4j-config
-              mountPath: /log4j-config
-        - name: jmx-exporter
-          image: bitnami/jmx-exporter:0.20.0
-          command: ["java", "-Xms256m", "-Xmx1024m", "-jar", "jmx_prometheus_httpserver.jar"]
-          args: ["5556", "/jmx-exporter-config/config.yaml"]
-          ports:
-            - containerPort: 5556
           livenessProbe:
             tcpSocket:
               port: 5556
@@ -124,21 +127,53 @@ spec:
             # it has been reported that in cases with many topics to synchronize, it takes a long time for the first request.
             timeoutSeconds: 300
             periodSeconds: 300
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 2
-              memory: 1.5Gi
           volumeMounts:
+            - name: mm2-config
+              mountPath: /config
+            - name: log4j-config
+              mountPath: /log4j-config
+            - name: jmx-exporter-jar
+              mountPath: /jmx-exporter-jar
             - mountPath: /jmx-exporter-config
               name: jmx-exporter-config
+
+#        - name: jmx-exporter
+#          image: bitnami/jmx-exporter:0.20.0
+#          command: ["java", "-Xms256m", "-Xmx1024m", "-jar", "jmx_prometheus_httpserver.jar"]
+#          args: ["5556", "/jmx-exporter-config/config.yaml"]
+#          ports:
+#            - containerPort: 5556
+#          livenessProbe:
+#            tcpSocket:
+#              port: 5556
+#            initialDelaySeconds: 15
+#            timeoutSeconds: 100
+#            periodSeconds: 300
+#          readinessProbe:
+#            httpGet:
+#              path: /
+#              port: 5556
+#            initialDelaySeconds: 30
+#            # it has been reported that in cases with many topics to synchronize, it takes a long time for the first request.
+#            timeoutSeconds: 300
+#            periodSeconds: 300
+#          resources:
+#            requests:
+#              cpu: 100m
+#              memory: 100Mi
+#            limits:
+#              cpu: 2
+#              memory: 1.5Gi
+#          volumeMounts:
+#            - mountPath: /jmx-exporter-config
+#              name: jmx-exporter-config
       volumes:
         - name: mm2-config-template
           configMap:
             name: mm2-config-template
         - name: mm2-config
+          emptyDir: {}
+        - name: jmx-exporter-jar
           emptyDir: {}
         - name: log4j-config
           configMap:

--- a/mirror-maker-2/flexible/config/jmx-exporter-config.yaml
+++ b/mirror-maker-2/flexible/config/jmx-exporter-config.yaml
@@ -1,5 +1,4 @@
 # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
-jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi
 
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true
@@ -53,7 +52,7 @@ rules:
   #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
   #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
   #kafka.consumer:type=producer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.*)><>(.*record-[^:]*|.*error[^:]*|.*outgoing-[^:]*|.*incoming-[^:]*|.*buffer-[^:]*)
+  - pattern: kafka.(.+)<type=(consumer-fetch-manager|consumer-coordinator|consumer|producer|producer-topic)-metrics, client-id=(.*)><>(.*record-send-total|.*error-total|outgoing-.+-total|incoming-.*-total|.*buffer-.*-total|.*buffer-.*-bytes)
     name: kafka_$2_$4
     labels:
       clientId: "$3"
@@ -77,7 +76,7 @@ rules:
   #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
   #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped|.+-avg-time-ms)
     name: kafka_connect_$1_$4
     labels:
       connector: "$2"
@@ -97,21 +96,14 @@ rules:
     type: GAUGE
 
   #kafka.connect:type=connect-worker-metrics
-  - pattern: kafka.connect<type=connect-worker-metrics><>([a-z-]+)
+  - pattern: kafka.connect<type=connect-worker-metrics><>(.+-count|.+-total|.+-ms)
     name: kafka_connect_worker_$1
     help: "Kafka Connect JMX metric worker"
     cache: true
     type: GAUGE
 
-  #kafka.connect:type=connect-worker-rebalance-metrics
-  - pattern: kafka.connect<type=connect-worker-rebalance-metrics><>([a-z-]+)
-    name: kafka_connect_worker_rebalance_$1
-    help: "Kafka Connect JMX metric rebalance information"
-    cache: true
-    type: GAUGE
-
   #kafka.connect:type=MirrorSourceConnector
-  - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>([a-z-_]+)
+  - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms|.+-rate)
     name: kafka_connect_mirror_mirrorsourceconnector_$4
     labels:
       target: "$1"
@@ -122,7 +114,7 @@ rules:
     type: GAUGE
 
   #kafka.connect:type=MirrorCheckpointConnector
-  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+), partition=(.+)><>([a-z-_]+)
+  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms)
     name: kafka_connect_mirror_mirrorcheckpointconnector_$6
     labels:
       source: "$1"

--- a/mirror-maker-2/flexible/deployment.yaml
+++ b/mirror-maker-2/flexible/deployment.yaml
@@ -20,6 +20,17 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       terminationGracePeriodSeconds: 30
+      initContainers:
+        - name: copy-jmx-exporter-jar
+          image: bitnami/jmx-exporter:0.20.0
+          command:
+            - cp
+            - /opt/bitnami/jmx-exporter/jmx_prometheus_javaagent.jar
+            - /jmx-exporter-jar/jmx_prometheus_javaagent.jar
+
+          volumeMounts:
+            - name: jmx-exporter-jar
+              mountPath: /jmx-exporter-jar
       containers:
         - name: *app
           imagePullPolicy: IfNotPresent
@@ -31,9 +42,13 @@ spec:
               value: -Dlog4j.configuration=file:/log4j-config/connect-log4j.properties
             - name: JMX_PORT
               value: "5555"
+            - name: KAFKA_OPTS
+              value: "-javaagent:/jmx-exporter-jar/jmx_prometheus_javaagent.jar=5556:/jmx-exporter-config/config.yaml"
           command:
             - /opt/bitnami/kafka/bin/connect-mirror-maker.sh
             - /config/connect-mirror-maker.properties
+          ports:
+            - containerPort: 5556
           resources:
             requests:
               cpu: 400m
@@ -41,17 +56,6 @@ spec:
             limits:
               cpu: "6"
               memory: 5Gi
-          volumeMounts:
-            - name: mm2-config
-              mountPath: /config
-            - name: log4j-config
-              mountPath: /log4j-config
-        - name: jmx-exporter
-          image: bitnami/jmx-exporter:0.20.0
-          command: ["java", "-Xms256m", "-Xmx1024m", "-jar", "jmx_prometheus_httpserver.jar"]
-          args: ["5556", "/jmx-exporter-config/config.yaml"]
-          ports:
-            - containerPort: 5556
           livenessProbe:
             tcpSocket:
               port: 5556
@@ -66,20 +70,22 @@ spec:
             # it has been reported that in cases with many topics to synchronize, it takes a long time for the first request.
             timeoutSeconds: 300
             periodSeconds: 300
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 2
-              memory: 1.5Gi
           volumeMounts:
+            - name: mm2-config
+              mountPath: /config
+            - name: log4j-config
+              mountPath: /log4j-config
+            - name: jmx-exporter-jar
+              mountPath: /jmx-exporter-jar
             - mountPath: /jmx-exporter-config
               name: jmx-exporter-config
+
       volumes:
         - name: mm2-config
           configMap:
             name: mm2-config
+        - name: jmx-exporter-jar
+          emptyDir: {}
         - name: log4j-config
           configMap:
             name: mm2-log4j-config


### PR DESCRIPTION
Starting the jmx exporter as a java agent increased very much the performance of it. 
On the energy platform use case it reduced serving the metrics from **32-40s** to **3-4s** .

Also the overall performance of the mm2  container seems to have improved.
Here are some links:
- In progress [mm2 sync dash](https://grafana.dev.merit.uw.systems/d/spCQwc0mz/kafka-mirror-maker-2?orgId=1&from=1701684067000&to=now&var-datasource=default&var-namespace=energy-platform&var-app=mm2&var-app_kubernetes_io_name=&var-source=source&refresh=10s)
- in progress [container dash](https://grafana.dev.merit.uw.systems/d/faeKgjeMkv2/kubernetes-pod-usage-vs-resource-app-v2?orgId=1&var-namespace=energy-platform&var-app=All&var-pod=mm2-7b8d977f79-nn5rt&var-app_kubernetes_io_name=All&var-container=All&from=1701684067000&to=now&refresh=1m)


