### PR TITLE
Requiring CNs to be prefixed with the origin namespace when issuing c…

### DIFF
--- a/bitnami/shared/kyverno/require-ns-in-certificate-cn.yaml
+++ b/bitnami/shared/kyverno/require-ns-in-certificate-cn.yaml
@@ -23,6 +23,9 @@ spec:
           - key: "{{ request.object.spec.issuerRef.name || '' }}"
             operator: Equals
             value: kafka-shared-selfsigned-issuer
+          - key: "{{ request.object.spec.issuerRef.name || '' }}"
+            operator: Equals
+            value: aws-pca  
       validate:
         message: "CN must be prefixed with the namespace"
         pattern:


### PR DESCRIPTION
…erts using the aws pca issuer