### PR TITLE
Fix OL annotations for Kafka services

### DIFF
--- a/bitnami/pubsub/kafka-non-tls/kustomization.yaml
+++ b/bitnami/pubsub/kafka-non-tls/kustomization.yaml
@@ -4,3 +4,34 @@ kind: Kustomization
 resources:
   - upstream
   - ../../shared/logging
+
+components:
+  - ../../../shared/opslevel
+
+patches:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: kafka-non-tls-exporter
+      namespace: pubsub
+    patch: |-
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1description
+        value: Metrics exporter for the non-TLS Kafka cluster
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1tier
+        value: tier_3
+  - target:
+      version: v1
+      group: apps
+      kind: StatefulSet
+      name: kafka-non-tls
+      namespace: pubsub
+    patch: |-
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1description
+        value: Kafka instance for the non-TLS Kafka cluster
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1tier
+        value: tier_1

--- a/bitnami/pubsub/kafka-shared/kustomization.yaml
+++ b/bitnami/pubsub/kafka-shared/kustomization.yaml
@@ -6,7 +6,36 @@ resources:
   - ../../shared/logging
   - certs.yaml
 
+components:
+  - ../../../shared/opslevel
+
 patches:
   - path: kafka-shared-admins.yaml
   - path: refresh-broker-certs.yaml
   - path: refresh-exporter-certs.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: kafka-shared-exporter
+      namespace: pubsub
+    patch: |-
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1description
+        value: Metrics exporter for shared Kafka
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1tier
+        value: tier_3
+  - target:
+      version: v1
+      group: apps
+      kind: StatefulSet
+      name: kafka-shared
+      namespace: pubsub
+    patch: |-
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1description
+        value: Kafka instance for the shared cluster
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1tier
+        value: tier_1

--- a/mirror-maker-2/active-passive-ssl/kustomization.yaml
+++ b/mirror-maker-2/active-passive-ssl/kustomization.yaml
@@ -5,6 +5,23 @@ kind: Kustomization
 resources:
   - deployment.yaml
 
+components:
+  - ../../shared/opslevel
+
+patches:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: mm2
+    patch: |-
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1description
+        value: Mirror maker with flexible setup
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1tier
+        value: tier_4
+
 configMapGenerator:
   - name: mm2-config-template
     files:

--- a/mirror-maker-2/flexible/kustomization.yaml
+++ b/mirror-maker-2/flexible/kustomization.yaml
@@ -5,6 +5,23 @@ kind: Kustomization
 resources:
   - deployment.yaml
 
+components:
+  - ../../shared/opslevel
+
+patches:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: mm2
+    patch: |-
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1description
+        value: Mirror maker with flexible setup
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1tier
+        value: tier_4
+
 configMapGenerator:
   - name: mm2-log4j-config
     files:

--- a/shared/opslevel/kustomization.yaml
+++ b/shared/opslevel/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+
+patches:
+  # add oss tag for objects running 3rd party software
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+    patch: &oss-patch |-
+      - op: add
+        path: /metadata/annotations/app.uw.systems~1tags.oss
+        value: "true"
+  - target:
+      version: v1
+      group: apps
+      kind: StatefulSet
+    patch: *oss-patch


### PR DESCRIPTION
* Add component to easily add `oss` tag for services running 3rd party
  software, and used these for the Kafka clusters
* Add required description, tier labels

Note: patches are made as inline JSON6902 patches because of[1]

[1] https://github.com/kubernetes-sigs/kustomize/issues/5554

Ticket: DENA-480