### PR TITLE
PLA2-86: mm2: make truststore optional for source and target

### DIFF
--- a/mirror-maker-2/active-passive-ssl/config/connect-mirror-maker-template.properties
+++ b/mirror-maker-2/active-passive-ssl/config/connect-mirror-maker-template.properties
@@ -77,8 +77,10 @@ sync.topic.acls.enabled={{.Env.SYNC_TOPIC_ACLS}}
 {{.Env.SOURCE_NAME}}.security.inter.broker.protocol=SSL
 {{.Env.SOURCE_NAME}}.security.protocol=SSL
 {{.Env.SOURCE_NAME}}.ssl.endpoint.identification.algorithm=
+{{ if eq .Env.SOURCE_TRUSTSTORE_REQUIRED "true" }}
 {{.Env.SOURCE_NAME}}.ssl.truststore.location={{.Env.SOURCE_TRUSTSTORE}}
 {{.Env.SOURCE_NAME}}.ssl.truststore.password={{.Env.SOURCE_TRUSTSTORE_PASSWORD}}
+{{ end }}
 {{.Env.SOURCE_NAME}}.ssl.keystore.location={{.Env.SOURCE_KEYSTORE}}
 {{.Env.SOURCE_NAME}}.ssl.keystore.password={{.Env.SOURCE_KEYSTORE_PASSWORD}}
 {{ end }}
@@ -89,8 +91,10 @@ sync.topic.acls.enabled={{.Env.SYNC_TOPIC_ACLS}}
 {{.Env.TARGET_NAME}}.ssl.enabled.protocols=TLSv1.2
 {{.Env.TARGET_NAME}}.security.protocol=SSL
 {{.Env.TARGET_NAME}}.ssl.endpoint.identification.algorithm=
+{{ if eq .Env.TARGET_TRUSTSTORE_REQUIRED "true" }}
 {{.Env.TARGET_NAME}}.ssl.truststore.location={{.Env.TARGET_TRUSTSTORE}}
 {{.Env.TARGET_NAME}}.ssl.truststore.password={{.Env.TARGET_TRUSTSTORE_PASSWORD}}
+{{ end }}
 {{.Env.TARGET_NAME}}.ssl.keystore.location={{.Env.TARGET_KEYSTORE}}
 {{.Env.TARGET_NAME}}.ssl.keystore.password={{.Env.TARGET_KEYSTORE_PASSWORD}}
 {{ end }}

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             # When target has SSL enabled, mirror maker uses JKS keystore and truststore encrypted by password to connect. Use properties below
             - name: TARGET_SSL_ENABLE
               value: "false"
-            # Whether the truststore for the source needs to be specified. For MSK sources this must be "false" and for hosted bitnami sources it must be "true". By default, it is set to "true".
+            # Whether the truststore for the target needs to be specified. For MSK sources this must be "false" and for hosted bitnami sources it must be "true". By default, it is set to "true".
             - name: TARGET_TRUSTSTORE_REQUIRED
               value: "true"
             # The location to the JKS truststore

--- a/mirror-maker-2/active-passive-ssl/deployment.yaml
+++ b/mirror-maker-2/active-passive-ssl/deployment.yaml
@@ -56,6 +56,9 @@ spec:
             # When source has SSL enabled, mirror maker uses JKS keystore and truststore encrypted by password to connect. Use properties below
             - name: SOURCE_SSL_ENABLE
               value: "false"
+            # Whether the truststore for the source needs to be specified. For MSK sources this must be "false" and for hosted bitnami sources it must be "true". By default, it is set to "true".
+            - name: SOURCE_TRUSTSTORE_REQUIRED
+              value: "true"
             # The location to the JKS truststore
             - name: SOURCE_TRUSTSTORE
             - name: SOURCE_TRUSTSTORE_PASSWORD
@@ -66,6 +69,9 @@ spec:
             # When target has SSL enabled, mirror maker uses JKS keystore and truststore encrypted by password to connect. Use properties below
             - name: TARGET_SSL_ENABLE
               value: "false"
+            # Whether the truststore for the source needs to be specified. For MSK sources this must be "false" and for hosted bitnami sources it must be "true". By default, it is set to "true".
+            - name: TARGET_TRUSTSTORE_REQUIRED
+              value: "true"
             # The location to the JKS truststore
             - name: TARGET_TRUSTSTORE
             - name: TARGET_TRUSTSTORE_PASSWORD


### PR DESCRIPTION
This is needed so that we can use it to mirror to/from MSK.