### PR TITLE
Fix Otel Kafka services failing OpsLevel checks

### DIFF
--- a/bitnami/otel/kafka-bitnami/opslevel.yaml
+++ b/bitnami/otel/kafka-bitnami/opslevel.yaml
@@ -1,21 +1,31 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: kafka-bitnami
+  name: &name kafka-bitnami
   namespace: otel
   annotations:
     "app.uw.systems/name": "Otel kafka"
     "app.uw.systems/description": "Kafka instance for Otel stack"
     "app.uw.systems/tier": tier_3
-    "app.uw.systems/repos.manifests": https://github.com/utilitywarehouse/kafka-manifests/bitnami/otel/kafka-bitnami"
+    "app.uw.systems/repos.manifests": "https://github.com/utilitywarehouse/kafka-manifests/bitnami/otel/kafka-bitnami"
+spec:
+  template:
+    metadata:
+      labels:
+        app: *name
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kafka-bitnami-exporter
+  name: &name kafka-bitnami-exporter
   namespace: "otel"
   annotations:
     "app.uw.systems/name": "Otel kafka metrics exporter"
     "app.uw.systems/description": "Metrics exporter for the otel Kafka instance"
     "app.uw.systems/tier": tier_4
-    "app.uw.systems/repos.manifests": https://github.com/utilitywarehouse/kafka-manifests/bitnami/otel/kafka-bitnami"
+    "app.uw.systems/repos.manifests": "https://github.com/utilitywarehouse/kafka-manifests/bitnami/otel/kafka-bitnami"
+spec:
+  template:
+    metadata:
+      labels:
+        app: *name


### PR DESCRIPTION
These were failing metrics tests because we failed to autogenerate links due to missing `app` labels on their pod spec's.

Also fix up some quoting on repo annotations so these link correctly in OpsLevel