### PR TITLE
Fix OpsLevel annotations for kafka-bitnami for Finance and Billing

### DIFF
--- a/bitnami/billing/kafka-bitnami/kustomization.yaml
+++ b/bitnami/billing/kafka-bitnami/kustomization.yaml
@@ -4,3 +4,9 @@ kind: Kustomization
 resources:
   - upstream
   - ../../shared/logging
+
+components:
+  - ../../../shared/opslevel
+
+patches:
+  - path: opslevel.yaml

--- a/bitnami/billing/kafka-bitnami/opslevel.yaml
+++ b/bitnami/billing/kafka-bitnami/opslevel.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: &name kafka-bitnami
+  namespace: billing
+  annotations:
+    "app.uw.systems/name": "Billing Kafka"
+    "app.uw.systems/description": "Kafka instance for Billing stack"
+    "app.uw.systems/tier": tier_3
+    "app.uw.systems/repos.manifests": "https://github.com/utilitywarehouse/kafka-manifests/bitnami/billing/kafka-bitnami"
+spec:
+  template:
+    metadata:
+      labels:
+        app: *name
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &name kafka-bitnami-exporter
+  namespace: billing
+  annotations:
+    "app.uw.systems/name": "Billing Kafka metrics exporter"
+    "app.uw.systems/description": "Metrics exporter for the Billing Kafka instance"
+    "app.uw.systems/tier": tier_4
+    "app.uw.systems/repos.manifests": "https://github.com/utilitywarehouse/kafka-manifests/bitnami/billing/kafka-bitnami"
+spec:
+  template:
+    metadata:
+      labels:
+        app: *name

--- a/bitnami/finance/kafka-bitnami/kustomization.yaml
+++ b/bitnami/finance/kafka-bitnami/kustomization.yaml
@@ -4,3 +4,9 @@ kind: Kustomization
 resources:
   - upstream
   - ../../shared/logging
+
+components:
+  - ../../../shared/opslevel
+
+patches:
+  - path: opslevel.yaml

--- a/bitnami/finance/kafka-bitnami/opslevel.yaml
+++ b/bitnami/finance/kafka-bitnami/opslevel.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: &name kafka-bitnami
+  namespace: finance
+  annotations:
+    "app.uw.systems/name": "Finance Kafka"
+    "app.uw.systems/description": "Kafka instance for Finance stack"
+    "app.uw.systems/tier": tier_3
+    "app.uw.systems/repos.manifests": "https://github.com/utilitywarehouse/kafka-manifests/bitnami/finance/kafka-bitnami"
+spec:
+  template:
+    metadata:
+      labels:
+        app: *name
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: &name kafka-bitnami-exporter
+  namespace: finance
+  annotations:
+    "app.uw.systems/name": "Finance Kafka metrics exporter"
+    "app.uw.systems/description": "Metrics exporter for the Finance Kafka instance"
+    "app.uw.systems/tier": tier_4
+    "app.uw.systems/repos.manifests": "https://github.com/utilitywarehouse/kafka-manifests/bitnami/finance/kafka-bitnami"
+spec:
+  template:
+    metadata:
+      labels:
+        app: *name


### PR DESCRIPTION
Currently our `kafka-bitnami` and `-exporter` services are still stuck in Beginner in OpsLevel for both our `finance` and `billing` namespaces.

Had a peek at Otel's [patch for OpsLevel](https://github.com/utilitywarehouse/kafka-manifests/blob/master/bitnami/otel/kafka-bitnami/opslevel.yaml) to see how it was resolved, and attempting to do the same 🙏 

Links:
- Finance services:
  - https://app.opslevel.com/services/kafka-bitnami_2
  - https://app.opslevel.com/services/kafka-bitnami-exporter_2
- Billing services:
  - https://app.opslevel.com/services/kafka-bitnami_4
  - https://app.opslevel.com/services/kafka-bitnami-exporter_4
  