### PR TITLE
DENA-885: kafka clients kyverno: do not set UW_KAFKA_TLS_AUTH env var automatically

### DIFF
--- a/bitnami/shared/kyverno/kafka-client-policies.yaml
+++ b/bitnami/shared/kyverno/kafka-client-policies.yaml
@@ -105,9 +105,6 @@ spec:
                   spec:
                     containers:
                       - name: "{{ element.name }}"
-                        env:
-                          - name: UW_KAFKA_TLS_AUTH
-                            value: "true"
                         volumeMounts:
                           - name: kafka-client-cert
                             mountPath: /certs
@@ -138,9 +135,6 @@ spec:
                   spec:
                     containers:
                       - name: "{{ element.name }}"
-                        env:
-                          - name: UW_KAFKA_TLS_AUTH
-                            value: "true"
                         volumeMounts:
                           - name: kafka-client-cert
                             mountPath: /certs


### PR DESCRIPTION
This caused some surprises, so it is better not to set automatically.

see https://linear.app/utilitywarehouse/issue/DENA-885/mtls-deployment-do-not-set-uw-kafka-tls-auth-env-var-automatically