### PR TITLE
Adjust default exclusions

### DIFF
--- a/kafka-connect-cluster/msk-backup/connector-payloads/backup-connector.json
+++ b/kafka-connect-cluster/msk-backup/connector-payloads/backup-connector.json
@@ -4,7 +4,7 @@
     "name": "msk-s3-backup-sink-all-parquet",
     "connector.class": "io.lenses.streamreactor.connect.aws.s3.sink.S3SinkConnector",
     "tasks.max": "2",
-    "topics.regex": "^(?!auth\\.iam-cerbos-audit-v1$)(?!__amazon_msk_canary$)(?!heartbeats$)(?!mm2-).*",
+    "topics.regex": "^(?!auth\\.iam-cerbos-audit-v1$)(?!__amazon_msk_canary$)((?!.*heartbeats$)(?!.*\\.checkpoints\\.internal$)(?!mm2-).*",
     "key.converter.schemas.enable": "false",
     "connect.s3.kcql": "insert into `uw-dev-pubsub-msk-backup:msk-backup-parquet` select * from `*` PARTITIONBY _topic, _partition STOREAS `PARQUET` PROPERTIES ('store.envelope'=true,'flush.count'=10000,'flush.interval'=1800, 'partition.include.keys'=false);",
     "value.converter.schemas.enable": "false",


### PR DESCRIPTION
Exclude heartbeats and checkpoint topics by default as they're created by mirror maker