### PR TITLE
otel kafka: updated to legacy bitnami images

### DIFF
--- a/bitnami/otel/kafka-bitnami/kustomization.yaml
+++ b/bitnami/otel/kafka-bitnami/kustomization.yaml
@@ -14,3 +14,11 @@ patches:
   - path: opslevel.yaml
   - path: refresh-broker-certs.yaml
   - path: refresh-exporter-certs.yaml
+
+images:
+  - name: docker.io/bitnami/jmx-exporter
+    newName: docker.io/bitnamilegacy/jmx-exporter
+  - name: docker.io/bitnami/kafka
+    newName: docker.io/bitnamilegacy/kafka
+  - name: docker.io/bitnami/kafka-exporter
+    newName: quay.io/utilitywarehouse/kafka-exporter


### PR DESCRIPTION
Replace bitnami repo with bitnamilegacy to make sure images can be pulled after the 28th of August.