### PR TITLE
all kafkas: updated to legacy binami images

### DIFF
--- a/bitnami/billing/kafka-bitnami/kustomization.yaml
+++ b/bitnami/billing/kafka-bitnami/kustomization.yaml
@@ -10,3 +10,11 @@ components:
 
 patches:
   - path: opslevel.yaml
+
+images:
+  - name: docker.io/bitnami/jmx-exporter
+    newName: docker.io/bitnamilegacy/jmx-exporter
+  - name: docker.io/bitnami/kafka
+    newName: docker.io/bitnamilegacy/kafka
+  - name: docker.io/bitnami/kafka-exporter
+    newName: quay.io/utilitywarehouse/kafka-exporter

--- a/bitnami/customer-billing/kafka-bitnami/kustomization.yaml
+++ b/bitnami/customer-billing/kafka-bitnami/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - upstream
   - ../../shared/logging
+
+images:
+  - name: docker.io/bitnami/jmx-exporter
+    newName: docker.io/bitnamilegacy/jmx-exporter
+  - name: docker.io/bitnami/kafka
+    newName: docker.io/bitnamilegacy/kafka
+  - name: docker.io/bitnami/kafka-exporter
+    newName: quay.io/utilitywarehouse/kafka-exporter

--- a/bitnami/energy-platform/kafka-bitnami/kustomization.yaml
+++ b/bitnami/energy-platform/kafka-bitnami/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - upstream
   - ../../shared/logging
+
+images:
+  - name: docker.io/bitnami/jmx-exporter
+    newName: docker.io/bitnamilegacy/jmx-exporter
+  - name: docker.io/bitnami/kafka
+    newName: docker.io/bitnamilegacy/kafka
+  - name: docker.io/bitnami/kafka-exporter
+    newName: quay.io/utilitywarehouse/kafka-exporter

--- a/bitnami/energy/kafka-bitnami/kustomization.yaml
+++ b/bitnami/energy/kafka-bitnami/kustomization.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - upstream
   - ../../shared/logging
+
+images:
+  - name: docker.io/bitnami/jmx-exporter
+    newName: docker.io/bitnamilegacy/jmx-exporter
+  - name: docker.io/bitnami/kafka
+    newName: docker.io/bitnamilegacy/kafka
+  - name: docker.io/bitnami/kafka-exporter
+    newName: quay.io/utilitywarehouse/kafka-exporter

--- a/bitnami/finance/kafka-bitnami/kustomization.yaml
+++ b/bitnami/finance/kafka-bitnami/kustomization.yaml
@@ -10,3 +10,11 @@ components:
 
 patches:
   - path: opslevel.yaml
+
+images:
+  - name: docker.io/bitnami/jmx-exporter
+    newName: docker.io/bitnamilegacy/jmx-exporter
+  - name: docker.io/bitnami/kafka
+    newName: docker.io/bitnamilegacy/kafka
+  - name: docker.io/bitnami/kafka-exporter
+    newName: quay.io/utilitywarehouse/kafka-exporter

--- a/bitnami/gen-yaml/namespace-kustomize-template.yaml
+++ b/bitnami/gen-yaml/namespace-kustomize-template.yaml
@@ -4,3 +4,11 @@ kind: Kustomization
 resources:
   - upstream
   - ../../shared/logging
+
+images:
+  - name: docker.io/bitnami/jmx-exporter
+    newName: docker.io/bitnamilegacy/jmx-exporter
+  - name: docker.io/bitnami/kafka
+    newName: docker.io/bitnamilegacy/kafka
+  - name: docker.io/bitnami/kafka-exporter
+    newName: quay.io/utilitywarehouse/kafka-exporter


### PR DESCRIPTION
After testing with Otel, it's safe to update for all