### PR TITLE
msk backup kafka connect: adjust resources

### DIFF
--- a/kafka-connect-cluster/msk-backup/statefulset.yaml
+++ b/kafka-connect-cluster/msk-backup/statefulset.yaml
@@ -98,4 +98,3 @@ spec:
           secret:
             # The name of the secret set in kafka-cert.yaml, holding the tls assets
             secretName: msk-backup-kafka-connect-cert
-

--- a/kafka-connect-cluster/msk-backup/statefulset.yaml
+++ b/kafka-connect-cluster/msk-backup/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
 
             # Update the heap options to match the maximum allocated
             - name: KAFKA_HEAP_OPTS
-              value: -Xmx3G -Xms1G
+              value: -Xmx4G -Xms1G
             - name: CONNECT_PLUGIN_PATH
               value: "/usr/share/java,/usr/share/confluent-hub-components/,/usr/share/extra-connectors"
             - name: POD_NAME
@@ -62,9 +62,12 @@ spec:
                   name: msk-backup-kafka-connect-jks-data
                   key: jks.password
           resources:
+            requests:
+              cpu: 0
+              memory: 1Gi
             limits:
               cpu: 2
-              memory: 4Gi
+              memory: 5.5Gi
           volumeMounts:
             - name: kafka-certificates
               mountPath: /etc/kafka-connect/certs


### PR DESCRIPTION
We got ```java.lang.OutOfMemoryError: Java heap space``` so bumping the heap together with the limits.
Also specify the requests, otherwise they're matching the limits
 