### PR TITLE
kafka connect export metrics

### DIFF
--- a/kafka-connect-cluster/generic-base/config/jmx-exporter-config.yaml
+++ b/kafka-connect-cluster/generic-base/config/jmx-exporter-config.yaml
@@ -1,127 +1,136 @@
 # See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
 
-lowercaseOutputName: true
+# Based on https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/shared-assets/jmx-exporter/kafka_connect.yml
+---
+lowercaseOutputName: false
 lowercaseOutputLabelNames: true
+whitelistObjectNames:
+  # Engine Application Versioning Info
+  - kafka.connect:type=app-info,client-id=*
+  # Connect Worker Rebalancing info
+  - kafka.connect:type=connect-worker-rebalance-metrics
+  # Connect Co-ordinator Info
+  - kafka.connect:type=connect-coordinator-metrics,*
+  - kafka.connect:type=connect-metrics,*
+  # Worker level metrics for the aggregate as well as per connector level
+  - kafka.connect:type=connect-worker-metrics
+  - kafka.connect:type=connect-worker-metrics,*
+  # Engine Connector Versioning Info
+  - kafka.connect:type=connector-metrics,*
+  # Task level metrics for every connector running in the current node.
+  - kafka.connect:type=*-task-metrics,*
+  - kafka.connect:type=task-error-metrics,*
+  #  Confluent Replicator JMX Stats
+  #  - confluent.replicator:type=confluent-replicator-task-metrics,*
+  # The two lines below are used to pull the Kafka Client Producer & consumer metrics from Connect Workers.
+  # If you care about Producer/Consumer metrics for Connect, please uncomment 2 lines below.
+  # Please note that this increases the scrape duration by about 1-2 seconds as it needs to parse a lot of data.
+  - "kafka.consumer:*"
+  - "kafka.producer:*"
+blacklistObjectNames:
+  # This will ignore the admin client metrics from KSQL server and will blacklist certain metrics
+  # that do not make sense for ingestion.
+  - "kafka.admin.client:*"
+  - "kafka.consumer:type=*,id=*"
+  - "kafka.producer:type=*,id=*"
+  - "kafka.producer:client-id=confluent.monitoring*,*"
+  - "kafka.*:type=kafka-metrics-count,*"
+  # - "kafka.*:type=app-info,*"
 rules:
-  #kafka.connect:type=app-info,client-id="{clientid}"
-  #kafka.consumer:type=app-info,client-id="{clientid}"
-  #kafka.producer:type=app-info,client-id="{clientid}"
-  - pattern: "kafka.(.+)<type=app-info, client-id=(.+)><>start-time-ms"
-    name: kafka_$1_start_time_seconds
-    labels:
-      clientId: "$2"
-    help: "Kafka $1 JMX metric start time seconds"
-    type: GAUGE
-    valueFactor: 0.001
-    cache: true
-  - pattern: "kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)"
-    name: kafka_$1_$3_info
+  # "kafka.schema.registry:type=app-info,id=*"
+  - pattern: "kafka.connect<type=app-info, client-id=(.+)><>(.+): (.+)"
+    name: "kafka_connect_app_info"
     value: 1
     labels:
-      clientId: "$2"
-      $3: "$4"
-    help: "Kafka $1 JMX metric info version and commit-id"
-    cache: true
-    type: GAUGE
-
-  #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|.+-lag)
-    name: kafka_$2_$6
+      client-id: "$1"
+      $2: "$3"
+    type: UNTYPED
+  # kafka.connect:type=connect-worker-rebalance-metrics
+  - pattern: "kafka.connect<type=connect-worker-rebalance-metrics><>([^:]+)"
+    name: "kafka_connect_connect_worker_rebalance_metrics_$1"
+  # kafka.connect:type=connect-coordinator-metrics,client-id=*
+  # kafka.connect:type=connect-metrics,client-id=*
+  - pattern: "kafka.connect<type=(.+), client-id=(.+)><>([^:]+)"
+    name: kafka_connect_$1_$3
     labels:
-      clientId: "$3"
-      topic: "$4"
-      partition: "$5"
-    help: "Kafka $1 JMX metric type $2"
-    cache: true
-    type: GAUGE
-
-  #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
-  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"
-  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total)
-    name: kafka_$2_$5
+      client_id: $2
+  # kafka.connect:type=connect-worker-metrics
+  - pattern: "kafka.connect<type=connect-worker-metrics><>([^:]+)"
+    name: kafka_connect_connect_worker_metrics_$1
     labels:
-      clientId: "$3"
-      topic: "$4"
-    help: "Kafka $1 JMX metric type $2"
-    cache: true
-    type: GAUGE
-
-  #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
-  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
-  #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
-  #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
-  #kafka.consumer:type=producer-metrics,client-id="{clientid}"
-  - pattern: kafka.(.+)<type=(consumer-fetch-manager|consumer-coordinator|consumer|producer|producer-topic)-metrics, client-id=(.*)><>(.*record-send-total|.*error-total|outgoing-.+-total|incoming-.*-total|.*buffer-.*-total|.*buffer-.*-bytes)
-    name: kafka_$2_$4
+      connector: "aggregate"
+  # kafka.connect:type=connect-worker-metrics,connector=*
+  - pattern: "kafka.connect<type=connect-worker-metrics, connector=(.+)><>([^:]+)"
+    name: kafka_connect_connect_worker_metrics_$2
     labels:
-      clientId: "$3"
-    help: "Kafka $1 JMX metric type $2 by client-id"
-    cache: true
-    type: GAUGE
-
-  #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
-  - pattern: "kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)"
-    name: kafka_connect_connector_status
+      connector: $1
+  # kafka.connect:type=connector-metrics,connector=*
+  - pattern: "kafka.connect<type=connector-metrics, connector=(.+)><>(.+): (.+)"
     value: 1
+    name: kafka_connect_connector_metrics
     labels:
-      connector: "$1"
-      task: "$2"
-      status: "$3"
-    help: "Kafka Connect JMX Connector status"
-    cache: true
-    type: GAUGE
+      connector: $1
+      $2: $3
+    type: UNTYPED
 
-  #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
-  #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
-  #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
-  #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
-  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped|.+-avg-time-ms)
-    name: kafka_connect_$1_$4
+  # kafka.connect:type=*-task-metrics,*
+  # kafka.connect:type=source-task-metrics,connector=*,task=*
+  # kafka.connect:type=sink-task-metrics,connector=*,task=*
+  # kafka.connect:type=connector-task-metrics,connector=*,task=*
+  - pattern: "kafka.connect<type=(.+)-task-metrics, connector=(.+), task=(\\d+)><>(.+): (.+)"
+    name: kafka_connect_$1_task_metrics_$4
     labels:
       connector: "$2"
       task: "$3"
-    help: "Kafka Connect JMX metric type $1"
-    cache: true
-    type: GAUGE
-
-  #kafka.connect:type=connector-metrics,connector="{connector}"
-  #kafka.connect:type=connect-worker-metrics,connector="{connector}"
-  - pattern: kafka.connect<type=connect-worker-metrics, connector=(.+)><>([a-z-]+)
-    name: kafka_connect_worker_$2
+  # kafka.connect:type=task-error-metrics,*
+  # kafka.connect:type=task-error-metrics,connector=*,task=*
+  - pattern: "kafka.connect<type=task-error-metrics, connector=(.+), task=(\\d+)><>([^:]+)"
+    name: kafka_connect_task_error_metrics_$3
     labels:
       connector: "$1"
-    help: "Kafka Connect JMX metric $1"
-    cache: true
-    type: GAUGE
-
-  #kafka.connect:type=connect-worker-metrics
-  - pattern: kafka.connect<type=connect-worker-metrics><>(.+-count|.+-total|.+-ms)
-    name: kafka_connect_worker_$1
-    help: "Kafka Connect JMX metric worker"
-    cache: true
-    type: GAUGE
-
-  #kafka.connect:type=MirrorSourceConnector
-  - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms|.+-rate)
-    name: kafka_connect_mirror_mirrorsourceconnector_$4
+      task: "$2"
+  # "kafka.consumer:type=app-info,client-id=*"
+  # "kafka.producer:type=app-info,client-id=*"
+  - pattern: "kafka.(.+)<type=app-info, client-id=(.+)><>(.+): (.+)"
+    value: 1
+    name: kafka_$1_app_info
     labels:
-      target: "$1"
-      topic: "$2"
-      partition: "$3"
-    help: "Kafka Mirror Maker 2 Source Connector metrics"
-    cache: true
+      client_type: $1
+      client_id: $2
+      $3: $4
+    type: UNTYPED
+  # "kafka.consumer:type=consumer-metrics,client-id=*, protocol=*, cipher=*"
+  # "kafka.consumer:type=type=consumer-fetch-manager-metrics,client-id=*, topic=*, partition=*"
+  # "kafka.producer:type=producer-metrics,client-id=*, protocol=*, cipher=*"
+  - pattern: "kafka.(.+)<type=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(.+):"
+    name: kafka_$1_$2_$9
     type: GAUGE
-
-  #kafka.connect:type=MirrorCheckpointConnector
-  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms)
-    name: kafka_connect_mirror_mirrorcheckpointconnector_$6
     labels:
-      source: "$1"
-      target: "$2"
-      group: "$3"
-      topic: "$4"
-      partition: "$5"
-    help: "Kafka Mirror Maker 2 Checkpoint Connector metrics"
-    cache: true
+      client_type: $1
+      $3: "$4"
+      $5: "$6"
+      $7: "$8"
+  # "kafka.consumer:type=consumer-node-metrics,client-id=*, node-id=*"
+  # "kafka.consumer:type=consumer-fetch-manager-metrics,client-id=*, topic=*"
+  # "kafka.producer:type=producer-node-metrics,client-id=*, node-id=*"
+  # "kafka.producer:type=producer-topic-metrics,client-id=*, topic=*"
+  - pattern: "kafka.(.+)<type=(.+), (.+)=(.+), (.+)=(.+)><>(.+):"
+    name: kafka_$1_$2_$7
     type: GAUGE
+    labels:
+      client_type: $1
+      $3: "$4"
+      $5: "$6"
+  # "kafka.consumer:type=consumer-fetch-manager-metrics,client-id=*"
+  # "kafka.consumer:type=consumer-metrics,client-id=*"
+  # "kafka.producer:type=producer-metrics,client-id=*"
+  - pattern: "kafka.(.+)<type=(.+), (.+)=(.+)><>(.+):"
+    name: kafka_$1_$2_$5
+    type: GAUGE
+    labels:
+      client_type: $1
+      $3: "$4"
+  - pattern: "kafka.(.+)<type=(.+)><>(.+):"
+    name: kafka_$1_$2_$3
+    labels:
+      client_type: $1

--- a/kafka-connect-cluster/generic-base/config/jmx-exporter-config.yaml
+++ b/kafka-connect-cluster/generic-base/config/jmx-exporter-config.yaml
@@ -1,0 +1,127 @@
+# See https://github.com/prometheus/jmx_exporter for more info about JMX Prometheus Exporter metrics
+
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+rules:
+  #kafka.connect:type=app-info,client-id="{clientid}"
+  #kafka.consumer:type=app-info,client-id="{clientid}"
+  #kafka.producer:type=app-info,client-id="{clientid}"
+  - pattern: "kafka.(.+)<type=app-info, client-id=(.+)><>start-time-ms"
+    name: kafka_$1_start_time_seconds
+    labels:
+      clientId: "$2"
+    help: "Kafka $1 JMX metric start time seconds"
+    type: GAUGE
+    valueFactor: 0.001
+    cache: true
+  - pattern: "kafka.(.+)<type=app-info, client-id=(.+)><>(commit-id|version): (.+)"
+    name: kafka_$1_$3_info
+    value: 1
+    labels:
+      clientId: "$2"
+      $3: "$4"
+    help: "Kafka $1 JMX metric info version and commit-id"
+    cache: true
+    type: GAUGE
+
+  #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"", partition="{partition}"
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+), partition=(.+)><>(.+-total|.+-lag)
+    name: kafka_$2_$6
+    labels:
+      clientId: "$3"
+      topic: "$4"
+      partition: "$5"
+    help: "Kafka $1 JMX metric type $2"
+    cache: true
+    type: GAUGE
+
+  #kafka.producer:type=producer-topic-metrics,client-id="{clientid}",topic="{topic}"
+  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}",topic="{topic}"
+  - pattern: kafka.(.+)<type=(.+)-metrics, client-id=(.+), topic=(.+)><>(.+-total)
+    name: kafka_$2_$5
+    labels:
+      clientId: "$3"
+      topic: "$4"
+    help: "Kafka $1 JMX metric type $2"
+    cache: true
+    type: GAUGE
+
+  #kafka.connect:type=kafka-metrics-count,client-id="{clientid}"
+  #kafka.consumer:type=consumer-fetch-manager-metrics,client-id="{clientid}"
+  #kafka.consumer:type=consumer-coordinator-metrics,client-id="{clientid}"
+  #kafka.consumer:type=consumer-metrics,client-id="{clientid}"
+  #kafka.consumer:type=producer-metrics,client-id="{clientid}"
+  - pattern: kafka.(.+)<type=(consumer-fetch-manager|consumer-coordinator|consumer|producer|producer-topic)-metrics, client-id=(.*)><>(.*record-send-total|.*error-total|outgoing-.+-total|incoming-.*-total|.*buffer-.*-total|.*buffer-.*-bytes)
+    name: kafka_$2_$4
+    labels:
+      clientId: "$3"
+    help: "Kafka $1 JMX metric type $2 by client-id"
+    cache: true
+    type: GAUGE
+
+  #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}<> status"
+  - pattern: "kafka.connect<type=connector-task-metrics, connector=(.+), task=(.+)><>status: ([a-z-]+)"
+    name: kafka_connect_connector_status
+    value: 1
+    labels:
+      connector: "$1"
+      task: "$2"
+      status: "$3"
+    help: "Kafka Connect JMX Connector status"
+    cache: true
+    type: GAUGE
+
+  #kafka.connect:type=task-error-metrics,connector="{connector}",task="{task}"
+  #kafka.connect:type=source-task-metrics,connector="{connector}",task="{task}"
+  #kafka.connect:type=sink-task-metrics,connector="{connector}",task="{task}"
+  #kafka.connect:type=connector-task-metrics,connector="{connector}",task="{task}"
+  - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped|.+-avg-time-ms)
+    name: kafka_connect_$1_$4
+    labels:
+      connector: "$2"
+      task: "$3"
+    help: "Kafka Connect JMX metric type $1"
+    cache: true
+    type: GAUGE
+
+  #kafka.connect:type=connector-metrics,connector="{connector}"
+  #kafka.connect:type=connect-worker-metrics,connector="{connector}"
+  - pattern: kafka.connect<type=connect-worker-metrics, connector=(.+)><>([a-z-]+)
+    name: kafka_connect_worker_$2
+    labels:
+      connector: "$1"
+    help: "Kafka Connect JMX metric $1"
+    cache: true
+    type: GAUGE
+
+  #kafka.connect:type=connect-worker-metrics
+  - pattern: kafka.connect<type=connect-worker-metrics><>(.+-count|.+-total|.+-ms)
+    name: kafka_connect_worker_$1
+    help: "Kafka Connect JMX metric worker"
+    cache: true
+    type: GAUGE
+
+  #kafka.connect:type=MirrorSourceConnector
+  - pattern: kafka.connect.mirror<type=MirrorSourceConnector, target=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms|.+-rate)
+    name: kafka_connect_mirror_mirrorsourceconnector_$4
+    labels:
+      target: "$1"
+      topic: "$2"
+      partition: "$3"
+    help: "Kafka Mirror Maker 2 Source Connector metrics"
+    cache: true
+    type: GAUGE
+
+  #kafka.connect:type=MirrorCheckpointConnector
+  - pattern: kafka.connect.mirror<type=MirrorCheckpointConnector, source=(.+), target=(.+), group=(.+), topic=(.+), partition=(.+)><>(.+-count|.+-total|.+-ms)
+    name: kafka_connect_mirror_mirrorcheckpointconnector_$6
+    labels:
+      source: "$1"
+      target: "$2"
+      group: "$3"
+      topic: "$4"
+      partition: "$5"
+    help: "Kafka Mirror Maker 2 Checkpoint Connector metrics"
+    cache: true
+    type: GAUGE

--- a/kafka-connect-cluster/generic-base/kustomization.yaml
+++ b/kafka-connect-cluster/generic-base/kustomization.yaml
@@ -5,7 +5,10 @@ resources:
   - kafka-cert.yaml
   - statefulset.yaml
 
-
+configMapGenerator:
+  - name: kafka-connect-jmx-exporter-config
+    files:
+      - config.yaml=config/jmx-exporter-config.yaml
 # Example on how to create the secret holding the jks data.
 #secretGenerator:
 #  - name: kafka-connect-jks-data

--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -38,7 +38,7 @@ spec:
         app: *app
         app.kubernetes.io/name: *app
       annotations:
-        prometheus.io/path: /
+        prometheus.io/path: /metrics
         prometheus.io/port: "5556"
         prometheus.io/scrape: "true"
     spec:

--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
         - name: copy-jmx-exporter
-          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:update-image-location
+          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:v1.4.0-1
           command:
             - cp
             - /lib/jmx_prometheus_javaagent-1.4.0.jar

--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
         - name: copy-jmx-exporter
-          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:v1.0.1-1
+          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:update-image
           command:
             - cp
             - /lib/jmx_prometheus_javaagent-1.0.1.jar

--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: *app
   annotations:
     prometheus.io/scrape: "false"
-    uw.health.aggregator.enable: 'false'
+    uw.health.aggregator.enable: "false"
 spec:
   clusterIP: None
   ports:
@@ -16,7 +16,6 @@ spec:
   selector:
     app.kubernetes.io/name: *app
 ---
-
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -38,8 +37,22 @@ spec:
       labels:
         app: *app
         app.kubernetes.io/name: *app
+      annotations:
+        prometheus.io/path: /
+        prometheus.io/port: "5556"
+        prometheus.io/scrape: "true"
     spec:
       terminationGracePeriodSeconds: 30
+      initContainers:
+        - name: copy-jmx-exporter
+          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:v1.0.1-1
+          command:
+            - cp
+            - /lib/jmx_prometheus_javaagent-1.0.1.jar
+            - /jmx-exporter/jmx_prometheus_javaagent.jar
+          volumeMounts:
+            - name: jmx-exporter
+              mountPath: /jmx-exporter
       containers:
         - name: *app
           imagePullPolicy: Always
@@ -48,7 +61,14 @@ spec:
             - containerPort: 8083
               name: api
               protocol: TCP
+            - containerPort: 5556
+              name: prometheus
+              protocol: TCP
           env:
+            - name: KAFKA_OPTS
+              value: "-javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=5556:/jmx-exporter-config/config.yaml"
+            - name: JMX_PORT
+              value: "5555"
             - name: CONNECT_REST_PORT
               value: "8083"
             - name: CONNECT_SECURITY_PROTOCOL
@@ -122,9 +142,18 @@ spec:
             - name: kafka-certificates
               mountPath: /etc/kafka-connect/certs
               readOnly: true
+            - name: jmx-exporter
+              mountPath: /jmx-exporter
+            - name: jmx-exporter-config
+              mountPath: /jmx-exporter-config
       volumes:
         - name: kafka-certificates
           secret:
             # The name of the secret set in kafka-cert.yaml, holding the tls assets
             secretName: TBD
-
+        - name: jmx-exporter
+          emptyDir: {}
+        - name: jmx-exporter-config
+          configMap:
+            defaultMode: 420
+            name: kafka-connect-jmx-exporter-config

--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
         - name: copy-jmx-exporter
-          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:v1.0.1-2
+          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:update-image-location
           command:
             - cp
             - /lib/jmx_prometheus_javaagent-1.0.1.jar

--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -45,6 +45,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
         - name: copy-jmx-exporter
+          imagePullPolicy: Always
           image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:update-image
           command:
             - cp

--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -45,8 +45,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
         - name: copy-jmx-exporter
-          imagePullPolicy: Always
-          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:update-image
+          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:v1.0.1-2
           command:
             - cp
             - /lib/jmx_prometheus_javaagent-1.0.1.jar

--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
           image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:update-image-location
           command:
             - cp
-            - /lib/jmx_prometheus_javaagent-1.0.1.jar
+            - /lib/jmx_prometheus_javaagent-1.4.0.jar
             - /jmx-exporter/jmx_prometheus_javaagent.jar
           volumeMounts:
             - name: jmx-exporter

--- a/kafka-connect-cluster/msk-backup/kustomization.yaml
+++ b/kafka-connect-cluster/msk-backup/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Kustomization
 
 namePrefix: "msk-backup-"
 
+# Overwrite the app labels from the base
+labels:
+  - pairs:
+      app.kubernetes.io/name: msk-backup-kafka-connect-cluster
+      app: msk-backup-kafka-connect-cluster
+
 resources:
   - ../generic-base
   - sa.yaml
@@ -19,7 +25,6 @@ configMapGenerator:
   - name: connector-payloads
     files:
       - backup-connector.yaml=connector-payloads/backup-connector.yaml
-
 # Example on how to create the secret holding the jks data.
 #secretGenerator:
 #  - name: msk-backup-kafka-connect-jks-data

--- a/kafka-connect-cluster/msk-backup/kustomization.yaml
+++ b/kafka-connect-cluster/msk-backup/kustomization.yaml
@@ -8,7 +8,8 @@ labels:
   - pairs:
       app.kubernetes.io/name: msk-backup-kafka-connect-cluster
       app: msk-backup-kafka-connect-cluster
-
+    includeTemplates: true
+    includeSelectors: true
 resources:
   - ../generic-base
   - sa.yaml


### PR DESCRIPTION
Export metrics from JMX using jmx exporter running as java agent.

This is based on confluent work from here: https://github.com/confluentinc/jmx-monitoring-stacks

Tested already, and these are the [gathered metrics](https://thanos.dev.aws.uw.systems/graph?g0.expr=sum%20by%20(__name__)%20(%7B__name__!%3D%22%22%2C%20app%3D%22kafka-connect-cluster%22%2C%20kubernetes_namespace%3D%22pubsub%22%7D)&g0.tab=1&g0.stacked=0&g0.range_input=1h&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=1&g0.store_matches=%5B%5D&g0.engine=thanos&g0.analyze=0&g0.tenant=)

Got an early dashboard [here](https://grafana.dev.aws.uw.systems/d/AEaSQ97mz/kafka-connect-cluster?orgId=1&from=now-15m&to=now&timezone=browser&var-kafka_connect_cluster_id=$__all&var-instance=$__all&var-connector=$__all&refresh=1m) 
