### PR TITLE
msk backup: copy lenses connector from docker image rather than downloading it

### DIFF
--- a/kafka-connect-cluster/msk-backup/statefulset.yaml
+++ b/kafka-connect-cluster/msk-backup/statefulset.yaml
@@ -77,10 +77,9 @@ spec:
       initContainers:
         - name: copy-lenses-connector
           image: quay.io/utilitywarehouse/docker-lensesio-kafka-connect-aws-s3-lib:v8.1.31-1
-          command:
-            - cp
-            - /opt/lib/kafka-connect-aws-s3-*.jar
-            - /usr/share/extra-connectors
+          command: ["/bin/sh", "-c", "--"]
+          args:
+            - cp /opt/lib/kafka-connect-aws-s3-*.jar /usr/share/extra-connectors
           volumeMounts:
             - name: extra-connectors
               mountPath: /usr/share/extra-connectors

--- a/kafka-connect-cluster/msk-backup/statefulset.yaml
+++ b/kafka-connect-cluster/msk-backup/statefulset.yaml
@@ -75,19 +75,12 @@ spec:
             - name: extra-connectors
               mountPath: /usr/share/extra-connectors
       initContainers:
-        - name: download-connectors
-          image: alpine
-          args:
-            - /bin/sh
-            - -c
-            - |
-              apk add --no-cache curl unzip
-              curl -sSL https://github.com/lensesio/stream-reactor/releases/download/${LENSES_IO_CONNECTOR_VERSION}/kafka-connect-aws-s3-${LENSES_IO_CONNECTOR_VERSION}.zip -o /tmp/kafka-connect-aws-s3.zip
-              unzip -d /tmp /tmp/kafka-connect-aws-s3.zip
-              cp /tmp/kafka-connect-aws-s3-${LENSES_IO_CONNECTOR_VERSION}/kafka-connect-aws-s3-assembly-${LENSES_IO_CONNECTOR_VERSION}.jar /usr/share/extra-connectors
-          env:
-            - name: LENSES_IO_CONNECTOR_VERSION
-              value: 8.1.31
+        - name: copy-lenses-connector
+          image: quay.io/utilitywarehouse/docker-lensesio-kafka-connect-aws-s3-lib:v8.1.31-1
+          command:
+            - cp
+            - /opt/lib/kafka-connect-aws-s3-*.jar
+            - /usr/share/extra-connectors
           volumeMounts:
             - name: extra-connectors
               mountPath: /usr/share/extra-connectors


### PR DESCRIPTION
We're building [the docker image with the lib](https://github.com/utilitywarehouse/docker-lensesio-kafka-connect-aws-s3-lib) beforehand to avoid dependency on GH at runtime. 