### PR TITLE
kafka connect: update the location of the jmx exporter jar & improve copy command

### DIFF
--- a/kafka-connect-cluster/generic-base/statefulset.yaml
+++ b/kafka-connect-cluster/generic-base/statefulset.yaml
@@ -45,11 +45,10 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
         - name: copy-jmx-exporter
-          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:v1.4.0-1
-          command:
-            - cp
-            - /lib/jmx_prometheus_javaagent-1.4.0.jar
-            - /jmx-exporter/jmx_prometheus_javaagent.jar
+          image: quay.io/utilitywarehouse/docker-jmx-prometheus-javaagent-lib:v1.4.0-2
+          command: ["/bin/sh", "-c", "--"]
+          args:
+            - cp /opt/lib/jmx_prometheus_javaagent-*.jar /jmx-exporter/jmx_prometheus_javaagent.jar
           volumeMounts:
             - name: jmx-exporter
               mountPath: /jmx-exporter


### PR DESCRIPTION
1. Jar moved in /opt/lib in this [PR](https://github.com/utilitywarehouse/docker-jmx-prometheus-javaagent-lib/pull/5)
2. Use wildcard when copying so we don't need to update the command whenever we update the version.