### PR TITLE
msk backup: suppress not useful logs

### DIFF
--- a/kafka-connect-cluster/msk-backup/config/connect-log4j.properties
+++ b/kafka-connect-cluster/msk-backup/config/connect-log4j.properties
@@ -1,0 +1,16 @@
+# Based on the default configuration from the docker image
+
+# Send logs only to the console.
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern =[%d] %p %m (%c)%n
+
+# default log levels
+log4j.logger.org.reflections=ERROR
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.I0Itec.zkclient=ERROR
+
+# Put lenses.io on WARN as it logs a lot on INFO
+log4j.logger.io.lenses.streamreactor=WARN

--- a/kafka-connect-cluster/msk-backup/config/connect-log4j.properties
+++ b/kafka-connect-cluster/msk-backup/config/connect-log4j.properties
@@ -12,7 +12,7 @@ log4j.logger.org.reflections=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.I0Itec.zkclient=ERROR
 
-# Put lenses.io on WARN as it logs a lot on INFO
+# Keep lenses.io on INFO. Move to WARN if it is too much
 log4j.logger.io.lenses.streamreactor=INFO
 # Suppressing "Got brand-new compressor [.zstd]" entries
 log4j.logger.org.apache.hadoop.io.compress.CodecPool=WARN

--- a/kafka-connect-cluster/msk-backup/config/connect-log4j.properties
+++ b/kafka-connect-cluster/msk-backup/config/connect-log4j.properties
@@ -13,4 +13,6 @@ log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.I0Itec.zkclient=ERROR
 
 # Put lenses.io on WARN as it logs a lot on INFO
-log4j.logger.io.lenses.streamreactor=WARN
+log4j.logger.io.lenses.streamreactor=INFO
+# Suppressing "Got brand-new compressor [.zstd]" entries
+log4j.logger.org.apache.hadoop.io.compress.CodecPool=WARN

--- a/kafka-connect-cluster/msk-backup/kustomization.yaml
+++ b/kafka-connect-cluster/msk-backup/kustomization.yaml
@@ -26,6 +26,9 @@ configMapGenerator:
   - name: connector-payloads
     files:
       - backup-connector.yaml=connector-payloads/backup-connector.yaml
+  - name: kafka-connect-log4j-config
+    files:
+      - connect-log4j.properties=config/connect-log4j.properties
 # Example on how to create the secret holding the jks data.
 #secretGenerator:
 #  - name: msk-backup-kafka-connect-jks-data
@@ -33,4 +36,3 @@ configMapGenerator:
 #      - ./secrets/jks.properties
 #    options:
 #      disableNameSuffixHash: true
-

--- a/kafka-connect-cluster/msk-backup/statefulset.yaml
+++ b/kafka-connect-cluster/msk-backup/statefulset.yaml
@@ -61,6 +61,8 @@ spec:
                   # the name of the secret that holds the data for jks
                   name: msk-backup-kafka-connect-jks-data
                   key: jks.password
+            - name: KAFKA_LOG4J_OPTS
+              value: -Dlog4j.configuration=file:/log4j-config/connect-log4j.properties
           resources:
             requests:
               cpu: 0
@@ -74,6 +76,8 @@ spec:
               readOnly: true
             - name: extra-connectors
               mountPath: /usr/share/extra-connectors
+            - name: log4j-config
+              mountPath: /log4j-config
       initContainers:
         - name: copy-lenses-connector
           image: quay.io/utilitywarehouse/docker-lensesio-kafka-connect-aws-s3-lib:v8.1.31-1
@@ -90,3 +94,6 @@ spec:
           secret:
             # The name of the secret set in kafka-cert.yaml, holding the tls assets
             secretName: msk-backup-kafka-connect-cert
+        - name: log4j-config
+          configMap:
+            name: kafka-connect-log4j-config


### PR DESCRIPTION
Log was full of ```Got brand-new compressor [.zstd]```

Keep lenses.io connector on INFO, as logs seem useful and not that frequent.
