### PR TITLE
msk-backup-kafka-connect :fix kustomize base to be able have multiple inheritance

### DIFF
--- a/kafka-connect-cluster/msk-backup/connector-payloads/backup-connector.yaml
+++ b/kafka-connect-cluster/msk-backup/connector-payloads/backup-connector.yaml
@@ -1,14 +1,13 @@
----
 name: msk-s3-backup-sink-all-parquet
 config:
   name: msk-s3-backup-sink-all-parquet
   connector.class: io.lenses.streamreactor.connect.aws.s3.sink.S3SinkConnector
-  tasks.max: '2'
+  tasks.max: "2"
   # include all topic, except:
   # - all topics created by mirror maker
   # - auth.iam-cerbos-audit-v1 currently this one can not be indexed due to an issue with the headers
   topics.regex: ^(?!auth\.iam-cerbos-audit-v1$)(?!__amazon_msk_canary$)(?!.*heartbeats$)(?!.*\.checkpoints\.internal$)(?!mm2-).*
-  key.converter.schemas.enable: 'false'
+  key.converter.schemas.enable: "false"
   # consume from all topics, thus we need to specify the topic in the partitioning part.
   # using the Parquet format, as this is the most performant both for backup and restoring
   # 'store.envelope'=true - so that we can restore headers, timestamp, etc
@@ -21,10 +20,10 @@ config:
     'flush.count'=10000,
     'flush.interval'=1800,
     'partition.include.keys'=false);
-  value.converter.schemas.enable: 'false'
+  value.converter.schemas.enable: "false"
   connect.s3.aws.auth.mode: Default
   connect.s3.compression.codec: zstd
-  connect.s3.compression.level: '9'
+  connect.s3.compression.level: "9"
   connect.s3.aws.region: eu-west-1
   value.converter: org.apache.kafka.connect.converters.ByteArrayConverter
   key.converter: org.apache.kafka.connect.converters.ByteArrayConverter

--- a/kafka-connect-cluster/msk-backup/kafka-cert.yaml
+++ b/kafka-connect-cluster/msk-backup/kafka-cert.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/kafka-connect-cluster/msk-backup/kafka-cert.yaml
+++ b/kafka-connect-cluster/msk-backup/kafka-cert.yaml
@@ -12,3 +12,4 @@ spec:
         key: jks.password
         name: msk-backup-kafka-connect-jks-data # the name of the secret that holds the data for jks
   secretName: msk-backup-kafka-connect-cert # the name of the secret that will be loaded with tls assets
+

--- a/kafka-connect-cluster/msk-backup/kafka-cert.yaml
+++ b/kafka-connect-cluster/msk-backup/kafka-cert.yaml
@@ -12,4 +12,3 @@ spec:
         key: jks.password
         name: msk-backup-kafka-connect-jks-data # the name of the secret that holds the data for jks
   secretName: msk-backup-kafka-connect-cert # the name of the secret that will be loaded with tls assets
-

--- a/kafka-connect-cluster/msk-backup/kustomization.yaml
+++ b/kafka-connect-cluster/msk-backup/kustomization.yaml
@@ -30,9 +30,9 @@ configMapGenerator:
     files:
       - connect-log4j.properties=config/connect-log4j.properties
 # Example on how to create the secret holding the jks data.
-#secretGenerator:
-#  - name: msk-backup-kafka-connect-jks-data
-#    envs:
-#      - ./secrets/jks.properties
-#    options:
-#      disableNameSuffixHash: true
+secretGenerator:
+  - name: kafka-connect-jks-data
+    envs:
+      - ./secrets/jks.properties
+    options:
+      disableNameSuffixHash: true

--- a/kafka-connect-cluster/msk-backup/kustomization.yaml
+++ b/kafka-connect-cluster/msk-backup/kustomization.yaml
@@ -29,7 +29,8 @@ configMapGenerator:
   - name: kafka-connect-log4j-config
     files:
       - connect-log4j.properties=config/connect-log4j.properties
-# Example on how to create the secret holding the jks data.
+
+# When using this base, jks.properties must be filled with a proper value and the secret generator must be replaced.
 secretGenerator:
   - name: kafka-connect-jks-data
     envs:

--- a/kafka-connect-cluster/msk-backup/secrets/jks.properties
+++ b/kafka-connect-cluster/msk-backup/secrets/jks.properties
@@ -1,1 +1,2 @@
+# Sample file including the keys needed for the jks data secret.
 #jks.password=

--- a/kafka-connect-cluster/msk-backup/secrets/jks.properties
+++ b/kafka-connect-cluster/msk-backup/secrets/jks.properties
@@ -1,0 +1,1 @@
+#jks.password=

--- a/kafka-connect-cluster/msk-backup/statefulset.yaml
+++ b/kafka-connect-cluster/msk-backup/statefulset.yaml
@@ -47,19 +47,19 @@ spec:
               valueFrom:
                 secretKeyRef:
                   # the name of the secret that holds the data for jks
-                  name: msk-backup-kafka-connect-jks-data
+                  name: kafka-connect-jks-data
                   key: jks.password
             - name: CONNECT_PRODUCER_SSL_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   # the name of the secret that holds the data for jks
-                  name: msk-backup-kafka-connect-jks-data
+                  name: kafka-connect-jks-data
                   key: jks.password
             - name: CONNECT_SSL_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   # the name of the secret that holds the data for jks
-                  name: msk-backup-kafka-connect-jks-data
+                  name: kafka-connect-jks-data
                   key: jks.password
             - name: KAFKA_LOG4J_OPTS
               value: -Dlog4j.configuration=file:/log4j-config/connect-log4j.properties
@@ -93,7 +93,7 @@ spec:
         - name: kafka-certificates
           secret:
             # The name of the secret set in kafka-cert.yaml, holding the tls assets
-            secretName: msk-backup-kafka-connect-cert
+            secretName: kafka-connect-cert
         - name: log4j-config
           configMap:
             name: kafka-connect-log4j-config

--- a/kafka-connect-cluster/msk-backup/statefulset.yaml
+++ b/kafka-connect-cluster/msk-backup/statefulset.yaml
@@ -47,19 +47,19 @@ spec:
               valueFrom:
                 secretKeyRef:
                   # the name of the secret that holds the data for jks
-                  name: kafka-connect-jks-data
+                  name: msk-backup-kafka-connect-jks-data
                   key: jks.password
             - name: CONNECT_PRODUCER_SSL_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   # the name of the secret that holds the data for jks
-                  name: kafka-connect-jks-data
+                  name: msk-backup-kafka-connect-jks-data
                   key: jks.password
             - name: CONNECT_SSL_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   # the name of the secret that holds the data for jks
-                  name: kafka-connect-jks-data
+                  name: msk-backup-kafka-connect-jks-data
                   key: jks.password
             - name: KAFKA_LOG4J_OPTS
               value: -Dlog4j.configuration=file:/log4j-config/connect-log4j.properties
@@ -93,7 +93,7 @@ spec:
         - name: kafka-certificates
           secret:
             # The name of the secret set in kafka-cert.yaml, holding the tls assets
-            secretName: kafka-connect-cert
+            secretName: msk-backup-kafka-connect-cert
         - name: log4j-config
           configMap:
             name: kafka-connect-log4j-config


### PR DESCRIPTION
In pubsub we have 2 instances of this base.
Without defining the secret kafka-connect-jks-data here, when building the whole pubsub namespace, the secret generated in the second instance was used also in the first instance, which obviously was causing issues.

See the diff here: https://github.com/utilitywarehouse/kubernetes-manifests/pull/117976#issuecomment-3397484089

Removed also the empty yaml docs & formatted.
