### PR TITLE
msk backup cluster: fix secret name

### DIFF
--- a/kafka-connect-cluster/msk-backup/statefulset.yaml
+++ b/kafka-connect-cluster/msk-backup/statefulset.yaml
@@ -93,7 +93,7 @@ spec:
         - name: kafka-certificates
           secret:
             # The name of the secret set in kafka-cert.yaml, holding the tls assets
-            secretName: kafka-connect-cert
+            secretName: msk-backup-kafka-connect-cert
         - name: log4j-config
           configMap:
             name: kafka-connect-log4j-config


### PR DESCRIPTION
Went to far with the updates of the secrets [in the previous PR ](https://github.com/utilitywarehouse/kafka-manifests/pull/97/files#diff-b0ae5e3affb7e3a9b6498ce169251171c0e7e100f748cb0e4034a029cd710998L96).

Reverting the change for this field.