### PR TITLE
feat: add staging-ept bitnami kafka manifests [EPTD-451]

### DIFF
--- a/bitnami/Makefile
+++ b/bitnami/Makefile
@@ -32,6 +32,19 @@ gen-finance-platform-bitnami-kafka-non-tls:
 	  --entrypoint=/bin/sh \
 	  alpine/helm ./gen-yaml/gen
 
+.PHONY: gen-staging-ept-bitnami-kafka-non-tls
+gen-staging-ept-bitnami-kafka-non-tls:
+	docker run -ti --rm \
+	  -v $${PWD}:/opt/manifests \
+	  -e BITNAMI_KAFKA_RELEASE=${BITNAMI_KAFKA_RELEASE} \
+	  -e NS="staging-ept" \
+	  -e NAME="kafka-bitnami" \
+	  -e KRAFT_CLUSTERID="N0IxNTA5QjJEMTg3NDk4Q0" \
+	  -e VALUES=${VALUES_NON_TLS} \
+	  --workdir=/opt/manifests \
+	  --entrypoint=/bin/sh \
+	  alpine/helm ./gen-yaml/gen
+
 .PHONY: gen-customer-billing-kafka-non-tls
 gen-customer-billing-kafka-non-tls:
 	docker run -ti --rm \

--- a/bitnami/staging-ept/kafka-bitnami/kustomization.yaml
+++ b/bitnami/staging-ept/kafka-bitnami/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - upstream
+  - ../../shared/logging
+
+images:
+  - name: docker.io/bitnami/jmx-exporter
+    newName: docker.io/bitnamilegacy/jmx-exporter
+  - name: docker.io/bitnami/kafka
+    newName: docker.io/bitnamilegacy/kafka
+  - name: docker.io/bitnami/kafka-exporter
+    newName: quay.io/utilitywarehouse/kafka-exporter

--- a/bitnami/staging-ept/kafka-bitnami/upstream/kafka.yaml
+++ b/bitnami/staging-ept/kafka-bitnami/upstream/kafka.yaml
@@ -1,0 +1,604 @@
+---
+# Source: kafka/templates/kafka-metrics-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-bitnami-exporter
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cluster-metrics
+automountServiceAccountToken: true
+
+---
+# Source: kafka/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-bitnami
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: kafka
+  annotations:
+automountServiceAccountToken: true
+
+---
+# Source: kafka/templates/jmx-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-bitnami-jmx-configuration
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+data:
+  jmx-kafka-prometheus.yml: |-
+    jmxUrl: service:jmx:rmi:///jndi/rmi://127.0.0.1:5555/jmxrmi
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    ssl: false
+    whitelistObjectNames: ["kafka.controller:*","kafka.server:*","java.lang:*","kafka.network:*","kafka.log:*"]
+    rules:
+      - pattern: kafka.controller<type=(ControllerChannelManager), name=(QueueSize), broker-id=(\d+)><>(Value)
+        name: kafka_controller_$1_$2_$4
+        labels:
+          broker_id: "$3"
+      - pattern: kafka.controller<type=(ControllerChannelManager), name=(TotalQueueSize)><>(Value)
+        name: kafka_controller_$1_$2_$3
+      - pattern: kafka.controller<type=(KafkaController), name=(.+)><>(Value)
+        name: kafka_controller_$1_$2_$3
+      - pattern: kafka.controller<type=(ControllerStats), name=(.+)><>(Count)
+        name: kafka_controller_$1_$2_$3
+      - pattern : kafka.network<type=(Processor), name=(IdlePercent), networkProcessor=(.+)><>(Value)
+        name: kafka_network_$1_$2_$4
+        labels:
+          network_processor: $3
+      - pattern : kafka.network<type=(RequestMetrics), name=(.+), request=(.+)><>(Count|Value)
+        name: kafka_network_$1_$2_$4
+        labels:
+          request: $3
+      - pattern : kafka.network<type=(SocketServer), name=(.+)><>(Count|Value)
+        name: kafka_network_$1_$2_$3
+      - pattern : kafka.network<type=(RequestChannel), name=(.+)><>(Count|Value)
+        name: kafka_network_$1_$2_$3
+      - pattern: kafka.server<type=(.+), name=(.+), topic=(.+)><>(Count|OneMinuteRate)
+        name: kafka_server_$1_$2_$4
+        labels:
+          topic: $3
+      - pattern: kafka.server<type=(ReplicaFetcherManager), name=(.+), clientId=(.+)><>(Value)
+        name: kafka_server_$1_$2_$4
+        labels:
+          client_id: "$3"
+      - pattern: kafka.server<type=(DelayedOperationPurgatory), name=(.+), delayedOperation=(.+)><>(Value)
+        name: kafka_server_$1_$2_$3_$4
+      - pattern: kafka.server<type=(.+), name=(.+)><>(Count|Value|OneMinuteRate)
+        name: kafka_server_$1_total_$2_$3
+      - pattern: kafka.server<type=(.+)><>(queue-size)
+        name: kafka_server_$1_$2
+      - pattern: java.lang<type=(.+), name=(.+)><(.+)>(\w+)
+        name: java_lang_$1_$4_$3_$2
+      - pattern: java.lang<type=(.+), name=(.+)><>(\w+)
+        name: java_lang_$1_$3_$2
+      - pattern : java.lang<type=(.*)>
+      - pattern: kafka.log<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
+        name: kafka_log_$1_$2
+        labels:
+          topic: $3
+          partition: $4
+---
+# Source: kafka/templates/scripts-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-bitnami-scripts
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+data:
+  setup.sh: |-
+    #!/bin/bash
+
+    ID="${MY_POD_NAME#"kafka-bitnami-"}"
+    # If process.roles is not set at all, it is assumed to be in ZooKeeper mode.
+    # https://kafka.apache.org/documentation/#kraft_role
+    
+    if [[ -f "/bitnami/kafka/data/meta.properties" ]]; then
+        if [[ $KAFKA_CFG_PROCESS_ROLES == "" ]]; then
+            export KAFKA_CFG_BROKER_ID="$(grep "broker.id" "/bitnami/kafka/data/meta.properties" | awk -F '=' '{print $2}')"
+        else
+            export KAFKA_CFG_NODE_ID="$(grep "node.id" "/bitnami/kafka/data/meta.properties" | awk -F '=' '{print $2}')"
+        fi
+    else
+        if [[ $KAFKA_CFG_PROCESS_ROLES == "" ]]; then
+            export KAFKA_CFG_BROKER_ID="$((ID + 0))"
+        else
+            export KAFKA_CFG_NODE_ID="$((ID + 0))"
+        fi
+    fi
+
+    if [[ $KAFKA_CFG_PROCESS_ROLES == *"controller"* && -z $KAFKA_CFG_CONTROLLER_QUORUM_VOTERS ]]; then
+        node_id=0
+        pod_id=0
+        while :
+        do 
+            VOTERS="${VOTERS}$node_id@kafka-bitnami-$pod_id.kafka-bitnami-headless.staging-ept.svc.cluster.local:9093"
+            node_id=$(( $node_id + 1 ))
+            pod_id=$(( $pod_id + 1 ))
+            if [[ $pod_id -ge 3 ]]; then
+                break
+            else
+                VOTERS="$VOTERS,"
+            fi
+        done
+        export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=$VOTERS
+    fi
+
+    # Configure zookeeper client
+
+    exec /entrypoint.sh /run.sh
+
+---
+# Source: kafka/templates/jmx-metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-bitnami-jmx-metrics
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+  annotations:
+    
+    prometheus.io/path: /
+    prometheus.io/port: '5556'
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http-metrics
+      port: 5556
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: kafka-bitnami
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/component: kafka
+
+---
+# Source: kafka/templates/kafka-metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-bitnami-metrics
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cluster-metrics
+  annotations:
+    
+    prometheus.io/path: /metrics
+    prometheus.io/port: '9308'
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http-metrics
+      port: 9308
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: kafka-bitnami
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/component: cluster-metrics
+
+---
+# Source: kafka/templates/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-bitnami-headless
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: kafka
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-client
+      port: 9092
+      protocol: TCP
+      targetPort: kafka-client
+    - name: tcp-internal
+      port: 9094
+      protocol: TCP
+      targetPort: kafka-internal
+    - name: tcp-controller
+      protocol: TCP
+      port: 9093
+      targetPort: kafka-ctlr
+  selector:
+    app.kubernetes.io/name: kafka-bitnami
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/component: kafka
+
+---
+# Source: kafka/templates/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-bitnami
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: kafka
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-client
+      port: 9092
+      protocol: TCP
+      targetPort: kafka-client
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: kafka-bitnami
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/component: kafka
+
+---
+# Source: kafka/templates/kafka-metrics-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-bitnami-exporter
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: cluster-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kafka-bitnami
+      app.kubernetes.io/instance: 22.1.1
+      app.kubernetes.io/component: cluster-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kafka-bitnami
+        helm.sh/chart: kafka-22.1.1
+        app.kubernetes.io/instance: 22.1.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: cluster-metrics
+      annotations:
+    spec:
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: kafka-bitnami
+                    app.kubernetes.io/instance: 22.1.1
+                    app.kubernetes.io/component: metrics
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: kafka-bitnami-exporter
+      containers:
+        - name: kafka-exporter
+          image: docker.io/bitnami/kafka-exporter:1.6.0-debian-11-r86
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          command:
+            - bash
+          args:
+            - -ce
+            - |
+              kafka_exporter \
+              --kafka.server=kafka-bitnami-0.kafka-bitnami-headless.staging-ept.svc.cluster.local:9092 \
+              --kafka.server=kafka-bitnami-1.kafka-bitnami-headless.staging-ept.svc.cluster.local:9092 \
+              --kafka.server=kafka-bitnami-2.kafka-bitnami-headless.staging-ept.svc.cluster.local:9092 \
+              --web.listen-address=:9308
+          ports:
+            - name: metrics
+              containerPort: 9308
+          resources: 
+            limits: {}
+            requests: {}
+          volumeMounts:
+      volumes:
+
+---
+# Source: kafka/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-bitnami
+  namespace: "staging-ept"
+  labels:
+    app.kubernetes.io/name: kafka-bitnami
+    helm.sh/chart: kafka-22.1.1
+    app.kubernetes.io/instance: 22.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: kafka
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kafka-bitnami
+      app.kubernetes.io/instance: 22.1.1
+      app.kubernetes.io/component: kafka
+  serviceName: kafka-bitnami-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kafka-bitnami
+        helm.sh/chart: kafka-22.1.1
+        app.kubernetes.io/instance: 22.1.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: kafka
+      annotations:
+        checksum/jmx-configuration: 79c1bafe55bb925c636df26600192277794f15b7bacc3a0b27866f47109e377b
+    spec:
+      
+      hostNetwork: false
+      hostIPC: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: kafka-bitnami
+                    app.kubernetes.io/instance: 22.1.1
+                    app.kubernetes.io/component: kafka
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: kafka-bitnami
+      containers:
+        - name: kafka
+          image: docker.io/bitnami/kafka:3.4.0-debian-11-r28
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1001
+          command:
+            - /scripts/setup.sh
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
+              value: 
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "INTERNAL"
+            - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "INTERNAL:PLAINTEXT,CLIENT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_CFG_LISTENERS
+              value: "INTERNAL://:9094,CLIENT://:9092,CONTROLLER://:9093"
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
+              value: "INTERNAL://$(MY_POD_NAME).kafka-bitnami-headless.staging-ept.svc.cluster.local:9094,CLIENT://$(MY_POD_NAME).kafka-bitnami-headless.staging-ept.svc.cluster.local:9092"
+            - name: ALLOW_PLAINTEXT_LISTENER
+              value: "yes"
+            - name: KAFKA_ZOOKEEPER_PROTOCOL
+              value: PLAINTEXT
+            - name: JMX_PORT
+              value: "5555"
+            - name: KAFKA_VOLUME_DIR
+              value: "/bitnami/kafka"
+            - name: KAFKA_LOG_DIR
+              value: "/opt/bitnami/kafka/logs"
+            - name: KAFKA_CFG_DELETE_TOPIC_ENABLE
+              value: "true"
+            - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
+              value: "false"
+            - name: KAFKA_HEAP_OPTS
+              value: "-Xmx1024m -Xms1024m"
+            - name: KAFKA_CFG_LOG_FLUSH_INTERVAL_MESSAGES
+              value: "10000"
+            - name: KAFKA_CFG_LOG_FLUSH_INTERVAL_MS
+              value: "1000"
+            - name: KAFKA_CFG_LOG_RETENTION_BYTES
+              value: "1073741824"
+            - name: KAFKA_CFG_LOG_RETENTION_CHECK_INTERVAL_MS
+              value: "300000"
+            - name: KAFKA_CFG_LOG_RETENTION_HOURS
+              value: "168"
+            - name: KAFKA_CFG_MESSAGE_MAX_BYTES
+              value: "1000012"
+            - name: KAFKA_CFG_LOG_SEGMENT_BYTES
+              value: "1073741824"
+            - name: KAFKA_CFG_LOG_DIRS
+              value: "/bitnami/kafka/data"
+            - name: KAFKA_CFG_DEFAULT_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "3"
+            - name: KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "2"
+            - name: KAFKA_CFG_NUM_IO_THREADS
+              value: "8"
+            - name: KAFKA_CFG_NUM_NETWORK_THREADS
+              value: "15"
+            - name: KAFKA_CFG_NUM_PARTITIONS
+              value: "15"
+            - name: KAFKA_CFG_NUM_RECOVERY_THREADS_PER_DATA_DIR
+              value: "8"
+            - name: KAFKA_CFG_SOCKET_RECEIVE_BUFFER_BYTES
+              value: "102400"
+            - name: KAFKA_CFG_SOCKET_REQUEST_MAX_BYTES
+              value: "104857600"
+            - name: KAFKA_CFG_SOCKET_SEND_BUFFER_BYTES
+              value: "102400"
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS
+              value: "6000"
+            - name: KAFKA_CFG_AUTHORIZER_CLASS_NAME
+              value: ""
+            - name: KAFKA_CFG_ALLOW_EVERYONE_IF_NO_ACL_FOUND
+              value: "true"
+            - name: KAFKA_CFG_SUPER_USERS
+              value: "User:admin"
+            - name: KAFKA_KRAFT_CLUSTER_ID
+              value: "N0IxNTA5QjJEMTg3NDk4Q0"  
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: "broker,controller"  
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"  
+            - name: KAFKA_ENABLE_KRAFT
+              value: "true"
+            - name: KAFKA_CFG_MIN_INSYNC_REPLICAS
+              value: "2"
+          ports:
+            - name: kafka-client
+              containerPort: 9092
+            - name: kafka-internal
+              containerPort: 9094
+            - name: kafka-ctlr
+              containerPort: 9093
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: kafka-client
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: kafka-client
+          startupProbe:
+            failureThreshold: 15
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            tcpSocket:
+              port: kafka-client
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/kafka
+            - name: logs
+              mountPath: /opt/bitnami/kafka/logs
+            - name: log4j-config
+              mountPath: /bitnami/kafka/config/log4j.properties
+              subPath: log4j.properties
+            - name: scripts
+              mountPath: /scripts/setup.sh
+              subPath: setup.sh
+        - name: jmx-exporter
+          image: docker.io/bitnami/jmx-exporter:0.18.0-debian-11-r18
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          command:
+            - java
+          args:
+            - -XX:MaxRAMPercentage=100
+            - -XshowSettings:vm
+            - -jar
+            - jmx_prometheus_httpserver.jar
+            - "5556"
+            - /etc/jmx-kafka/jmx-kafka-prometheus.yml
+          ports:
+            - name: metrics
+              containerPort: 5556
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+            - name: jmx-config
+              mountPath: /etc/jmx-kafka
+      volumes:
+        - name: log4j-config
+          configMap:
+            name: kafka-log4j-config
+        
+        - name: scripts
+          configMap:
+            name: kafka-bitnami-scripts
+            defaultMode: 0755
+        - name: jmx-config
+          configMap:
+            name: kafka-bitnami-jmx-configuration
+        - name: logs
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/bitnami/staging-ept/kafka-bitnami/upstream/kustomization.yaml
+++ b/bitnami/staging-ept/kafka-bitnami/upstream/kustomization.yaml
@@ -1,0 +1,51 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - kafka.yaml
+
+patches:
+  # Remove "app.kubernetes.io/instance" and "helm.sh/chart" labels as well as
+  # reference to these labels in selectors and affinity fields.
+  #
+  # Bitnami puts version string there and on Chart updates it means that
+  # Service labels are updated, but StatefulSet labels are not (immutable), so:
+  #   1. We are unable to "kubectl apply StatefulSet changes"
+  #   2. Service has no endpoints because the selector
+  #
+  # Remove these labels so we can cleanly update Chart versions
+  - patch: |-
+      - op: remove
+        path: /metadata/labels/app.kubernetes.io~1instance
+      - op: remove
+        path: /metadata/labels/helm.sh~1chart
+    target: {} # All resources
+  - patch: |-
+      - op: remove
+        path: /spec/selector/app.kubernetes.io~1instance
+    target:
+      version: v1
+      kind: Service
+  - patch: |-
+      - op: remove
+        path: /spec/selector/matchLabels/app.kubernetes.io~1instance
+      - op: remove
+        path: /spec/template/metadata/labels/app.kubernetes.io~1instance
+      - op: remove
+        path: /spec/template/metadata/labels/helm.sh~1chart
+      - op: remove
+        path: /spec/template/spec/affinity/podAntiAffinity/preferredDuringSchedulingIgnoredDuringExecution/0/podAffinityTerm/labelSelector/matchLabels/app.kubernetes.io~1instance
+    target:
+      group: apps
+      version: v1 # Deployment | StatefulSet
+  # remove these empty affinity nodes, as in Kustomize 5.0.x kustomize generates them as strings with value "null" instead of just null, and they can not be applied.
+  # added this issue in kustomize: https://github.com/kubernetes-sigs/kustomize/issues/5171
+  - patch: |-
+      - op: remove
+        path: /spec/template/spec/affinity/podAffinity
+      - op: remove
+        path: /spec/template/spec/affinity/nodeAffinity
+    target:
+      group: apps
+      version: v1 # Deployment | StatefulSet
+      kind: StatefulSet


### PR DESCRIPTION
## Summary

- Adds Helm-generated Bitnami Kafka manifests for the `staging-ept` namespace 
- Adds `gen-staging-ept-bitnami-kafka-non-tls` Makefile target to regenerate manifests when needed

## Context

Part of the EPT staging environment initiative (EPTD-451). This base is referenced by `kubernetes-manifests/dev-merit/staging-ept/kafka/bitnami/kustomization.yaml` (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)