### PR TITLE
mirror maker2: tune log4j levels to bring down the noise in the lgos

### DIFF
--- a/mirror-maker-2/active-passive-ssl/config/connect-log4j.properties
+++ b/mirror-maker-2/active-passive-ssl/config/connect-log4j.properties
@@ -8,6 +8,20 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR
 
+# Repeated per-partition/per-client startup chatter that drowns out real signal
+log4j.logger.org.apache.kafka.clients.Metadata=WARN
+log4j.logger.org.apache.kafka.common.utils.AppInfoParser=WARN
+log4j.logger.org.apache.kafka.common.metrics.Metrics=WARN
+log4j.logger.org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader=WARN
+log4j.logger.org.apache.kafka.connect.runtime.ConnectorConfig$EnrichedConnectorConfig=WARN
+
+# These log a huge dump of "not used yet" config keys on every task
+# (re)start; expected with MM2's shared consumer/producer/admin config
+# and not actionable, so drop below WARN.
+log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=ERROR
+
 # Enable the following for debugging the mirroring process
 
 #log4j.logger.org.apache.kafka.connect.mirror=DEBUG

--- a/mirror-maker-2/active-passive-ssl/config/connect-log4j.properties
+++ b/mirror-maker-2/active-passive-ssl/config/connect-log4j.properties
@@ -8,7 +8,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR
 
-# Repeated per-partition/per-client startup chatter that drowns out real signal
+# Repeated per-partition/per-client startup chatter that polutes the logs
 log4j.logger.org.apache.kafka.clients.Metadata=WARN
 log4j.logger.org.apache.kafka.common.utils.AppInfoParser=WARN
 log4j.logger.org.apache.kafka.common.metrics.Metrics=WARN

--- a/mirror-maker-2/flexible/config/connect-log4j.properties
+++ b/mirror-maker-2/flexible/config/connect-log4j.properties
@@ -8,6 +8,20 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR
 
+# Repeated per-partition/per-client startup chatter that polutes the logs
+log4j.logger.org.apache.kafka.clients.Metadata=WARN
+log4j.logger.org.apache.kafka.common.utils.AppInfoParser=WARN
+log4j.logger.org.apache.kafka.common.metrics.Metrics=WARN
+log4j.logger.org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader=WARN
+log4j.logger.org.apache.kafka.connect.runtime.ConnectorConfig$EnrichedConnectorConfig=WARN
+
+# These log a huge dump of "not used yet" config keys on every task
+# (re)start; expected with MM2's shared consumer/producer/admin config
+# and not actionable, so drop below WARN.
+log4j.logger.org.apache.kafka.clients.producer.ProducerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.consumer.ConsumerConfig=ERROR
+log4j.logger.org.apache.kafka.clients.admin.AdminClientConfig=ERROR
+
 # Enable the following for debugging the mirroring process
 
 #log4j.logger.org.apache.kafka.connect.mirror=DEBUG


### PR DESCRIPTION
Due to such noise, the important error logs might have been dropped when ingesting into Loki